### PR TITLE
Вернул старый атребут для colorPrimary

### DIFF
--- a/styles/attributes_android.json
+++ b/styles/attributes_android.json
@@ -120,7 +120,7 @@
     }
   ],
   "common": {
-    "colorPrimary": "?backgroundColorPrimary",
+    "colorPrimary": "?backgroundColorAccent",
     "colorControlNormal": "?graphicColorSecondary",
     "colorControlActivated": "?graphicColorSecondary",
     "android:textColor": "?textColorPrimary",


### PR DESCRIPTION
Вернул старый атребут для colorPrimary из-за неверного отображения цветов для некоторых компонентов

![image](https://github.com/core-ds/ui-primitives/assets/66694997/8591838b-2c94-42c5-a938-9af726f999d3)
