### PR TITLE
feat(styles): added typography tagline

### DIFF
--- a/styles/typography_web.json
+++ b/styles/typography_web.json
@@ -55,6 +55,14 @@
 		"font_weight": 700,
 		"font_family": "var(--font-family-system)"
 	},
+	"accent_tagline": {
+		"font_size": 12,
+		"line_height": 16,
+		"font_weight": 700,
+		"letter_spacing": 1.25,
+		"text_transform": "uppercase",
+		"font_family": "var(--font-family-system)"
+	},
 	"action_caps": {
 		"font_size": 12,
 		"line_height": 16,
@@ -109,6 +117,14 @@
 		"font_size": 11,
 		"line_height": 16,
 		"font_weight": 500,
+		"font_family": "var(--font-family-system)"
+	},
+	"action_tagline": {
+		"font_size": 12,
+		"line_height": 16,
+		"font_weight": 700,
+		"letter_spacing": 1.25,
+		"text_transform": "uppercase",
 		"font_family": "var(--font-family-system)"
 	},
 	"headline-mobile_large": {
@@ -315,6 +331,14 @@
 		"font_size": 11,
 		"line_height": 16,
 		"font_weight": 400,
+		"font_family": "var(--font-family-system)"
+	},
+	"paragraph_tagline": {
+		"font_size": 12,
+		"line_height": 16,
+		"font_weight": 500,
+		"letter_spacing": 1.25,
+		"text_transform": "uppercase",
 		"font_family": "var(--font-family-system)"
 	},
 	"promo-mobile_large": {


### PR DESCRIPTION
Добавляем стили tagline из фигмы, которые были добавлены в фигму для синхронизации со стилями из мобилки. Синхронизация только по названию, так как в мобилке используются другие размеры. Такая синхронизация нужна только для предсказуемости в SDUI-компонентах.

В одном из стилей CAPS исправлен вес, на тот что используется в фигме. В фигме он такой уже очень давно, и очевидно что в макетах он выглядит именно так.