### PR TITLE
feat: обновить цвета

### DIFF
--- a/styles/colors_bluetint.json
+++ b/styles/colors_bluetint.json
@@ -377,54 +377,6 @@
 		"web": "--color-dark-neutral-1300-press",
 		"alias": "neutralColor1300Press"
 	},
-	"dark_neutral_1500": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "neutral/1500",
-		"web": "--color-dark-neutral-1500",
-		"alias": "neutralColor1500",
-		"deprecated": true
-	},
-	"dark_neutral_1500_hover": {
-		"rgba": "rgba(186, 187, 194, 1)",
-		"hex": "#babbc2",
-		"figma": "neutral/1500/hover",
-		"web": "--color-dark-neutral-1500-hover",
-		"alias": "neutralColor1500Hover",
-		"deprecated": true
-	},
-	"dark_neutral_1500_inverted": {
-		"rgba": "rgba(18, 18, 19, 1)",
-		"hex": "#121213",
-		"figma": "neutral_inverted/1500",
-		"web": "--color-dark-neutral-1500-inverted",
-		"alias": "neutralColor1500Inverted",
-		"deprecated": true
-	},
-	"dark_neutral_1500_inverted_hover": {
-		"rgba": "rgba(63, 63, 69, 1)",
-		"hex": "#3f3f45",
-		"figma": "neutral_inverted/1500/hover",
-		"web": "--color-dark-neutral-1500-inverted-hover",
-		"alias": "neutralColor1500InvertedHover",
-		"deprecated": true
-	},
-	"dark_neutral_1500_inverted_press": {
-		"rgba": "rgba(95, 95, 102, 1)",
-		"hex": "#5f5f66",
-		"figma": "neutral_inverted/1500/press",
-		"web": "--color-dark-neutral-1500-inverted-press",
-		"alias": "neutralColor1500InvertedPress",
-		"deprecated": true
-	},
-	"dark_neutral_1500_press": {
-		"rgba": "rgba(160, 161, 169, 1)",
-		"hex": "#a0a1a9",
-		"figma": "neutral/1500/press",
-		"web": "--color-dark-neutral-1500-press",
-		"alias": "neutralColor1500Press",
-		"deprecated": true
-	},
 	"dark_neutral_200": {
 		"rgba": "rgba(33, 33, 36, 1)",
 		"hex": "#212124",
@@ -760,38 +712,6 @@
 		"figma": "neutral-translucent/1300/press",
 		"web": "--color-dark-neutral-translucent-1300-press",
 		"alias": "neutralTranslucentColor1300Press"
-	},
-	"dark_neutral_translucent_1500_hover": {
-		"rgba": "rgba(243, 245, 254, 0.75)",
-		"hex": "#bff3f5fe",
-		"figma": "neutral-translucent/1500/hover",
-		"web": "--color-dark-neutral-translucent-1500-hover",
-		"alias": "neutralTranslucentColor1500Hover",
-		"deprecated": true
-	},
-	"dark_neutral_translucent_1500_inverted_hover": {
-		"rgba": "rgba(2, 2, 10, 0.76)",
-		"hex": "#c202020a",
-		"figma": "neutral-translucent_inverted/1500/hover",
-		"web": "--color-dark-neutral-translucent-1500-inverted-hover",
-		"alias": "neutralTranslucentColor1500InvertedHover",
-		"deprecated": true
-	},
-	"dark_neutral_translucent_1500_inverted_press": {
-		"rgba": "rgba(1, 1, 12, 0.63)",
-		"hex": "#a101010c",
-		"figma": "neutral-translucent_inverted/1500/press",
-		"web": "--color-dark-neutral-translucent-1500-inverted-press",
-		"alias": "neutralTranslucentColor1500InvertedPress",
-		"deprecated": true
-	},
-	"dark_neutral_translucent_1500_press": {
-		"rgba": "rgba(239, 240, 252, 0.65)",
-		"hex": "#a6eff0fc",
-		"figma": "neutral-translucent/1500/press",
-		"web": "--color-dark-neutral-translucent-1500-press",
-		"alias": "neutralTranslucentColor1500Press",
-		"deprecated": true
 	},
 	"dark_neutral_translucent_200": {
 		"rgba": "rgba(225, 225, 248, 0.09)",
@@ -2242,54 +2162,6 @@
 		"web": "--color-light-neutral-1300-press",
 		"alias": "neutralColor1300Press"
 	},
-	"light_neutral_1500": {
-		"rgba": "rgba(18, 18, 19, 1)",
-		"hex": "#121213",
-		"figma": "neutral/1500",
-		"web": "--color-light-neutral-1500",
-		"alias": "neutralColor1500",
-		"deprecated": true
-	},
-	"light_neutral_1500_hover": {
-		"rgba": "rgba(63, 63, 69, 1)",
-		"hex": "#3f3f45",
-		"figma": "neutral/1500/hover",
-		"web": "--color-light-neutral-1500-hover",
-		"alias": "neutralColor1500Hover",
-		"deprecated": true
-	},
-	"light_neutral_1500_inverted": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "neutral_inverted/1500",
-		"web": "--color-light-neutral-1500-inverted",
-		"alias": "neutralColor1500Inverted",
-		"deprecated": true
-	},
-	"light_neutral_1500_inverted_hover": {
-		"rgba": "rgba(186, 187, 194, 1)",
-		"hex": "#babbc2",
-		"figma": "neutral_inverted/1500/hover",
-		"web": "--color-light-neutral-1500-inverted-hover",
-		"alias": "neutralColor1500InvertedHover",
-		"deprecated": true
-	},
-	"light_neutral_1500_inverted_press": {
-		"rgba": "rgba(160, 161, 169, 1)",
-		"hex": "#a0a1a9",
-		"figma": "neutral_inverted/1500/press",
-		"web": "--color-light-neutral-1500-inverted-press",
-		"alias": "neutralColor1500InvertedPress",
-		"deprecated": true
-	},
-	"light_neutral_1500_press": {
-		"rgba": "rgba(95, 95, 102, 1)",
-		"hex": "#5f5f66",
-		"figma": "neutral/1500/press",
-		"web": "--color-light-neutral-1500-press",
-		"alias": "neutralColor1500Press",
-		"deprecated": true
-	},
 	"light_neutral_200": {
 		"rgba": "rgba(237, 238, 240, 1)",
 		"hex": "#edeef0",
@@ -2625,38 +2497,6 @@
 		"figma": "neutral-translucent/1300/press",
 		"web": "--color-light-neutral-translucent-1300-press",
 		"alias": "neutralTranslucentColor1300Press"
-	},
-	"light_neutral_translucent_1500_hover": {
-		"rgba": "rgba(2, 2, 10, 0.76)",
-		"hex": "#c202020a",
-		"figma": "neutral-translucent/1500/hover",
-		"web": "--color-light-neutral-translucent-1500-hover",
-		"alias": "neutralTranslucentColor1500Hover",
-		"deprecated": true
-	},
-	"light_neutral_translucent_1500_inverted_hover": {
-		"rgba": "rgba(243, 245, 254, 0.75)",
-		"hex": "#bff3f5fe",
-		"figma": "neutral-translucent_inverted/1500/hover",
-		"web": "--color-light-neutral-translucent-1500-inverted-hover",
-		"alias": "neutralTranslucentColor1500InvertedHover",
-		"deprecated": true
-	},
-	"light_neutral_translucent_1500_inverted_press": {
-		"rgba": "rgba(239, 240, 252, 0.65)",
-		"hex": "#a6eff0fc",
-		"figma": "neutral-translucent_inverted/1500/press",
-		"web": "--color-light-neutral-translucent-1500-inverted-press",
-		"alias": "neutralTranslucentColor1500InvertedPress",
-		"deprecated": true
-	},
-	"light_neutral_translucent_1500_press": {
-		"rgba": "rgba(1, 1, 12, 0.63)",
-		"hex": "#a101010c",
-		"figma": "neutral-translucent/1500/press",
-		"web": "--color-light-neutral-translucent-1500-press",
-		"alias": "neutralTranslucentColor1500Press",
-		"deprecated": true
 	},
 	"light_neutral_translucent_200": {
 		"rgba": "rgba(30, 43, 68, 0.08)",
@@ -3813,14 +3653,6 @@
 		"web": "--color-static-accent-secondary-press",
 		"alias": "staticAccentColorSecondaryPress"
 	},
-	"static_bg_primary_dark": {
-		"rgba": "rgba(18, 18, 19, 1)",
-		"hex": "#121213",
-		"figma": "static/bg-dark/primary",
-		"alias": "staticBackgroundColorPrimaryDark",
-		"web": "--color-static-bg-primary-dark",
-		"deprecated": true
-	},
 	"static_neutral_0": {
 		"rgba": "rgba(255, 255, 255, 1)",
 		"hex": "#ffffff",
@@ -3946,54 +3778,6 @@
 		"figma": "static_neutral/1300/press",
 		"web": "--color-static-neutral-1300-press",
 		"alias": "staticNeutralColor1300Press"
-	},
-	"static_neutral_1500": {
-		"rgba": "rgba(18, 18, 19, 1)",
-		"hex": "#121213",
-		"figma": "static_neutral/1500",
-		"web": "--color-static-neutral-1500",
-		"alias": "staticNeutralColor1500",
-		"deprecated": true
-	},
-	"static_neutral_1500_hover": {
-		"rgba": "rgba(63, 63, 69, 1)",
-		"hex": "#3f3f45",
-		"figma": "static_neutral/1500/hover",
-		"web": "--color-static-neutral-1500-hover",
-		"alias": "staticNeutralColor1500Hover",
-		"deprecated": true
-	},
-	"static_neutral_1500_inverted": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "static_neutral_inverted/1500",
-		"web": "--color-static-neutral-1500-inverted",
-		"alias": "staticNeutralColor1500Inverted",
-		"deprecated": true
-	},
-	"static_neutral_1500_inverted_hover": {
-		"rgba": "rgba(186, 187, 194, 1)",
-		"hex": "#babbc2",
-		"figma": "static_neutral_inverted/1500/hover",
-		"web": "--color-static-neutral-1500-inverted-hover",
-		"alias": "staticNeutralColor1500InvertedHover",
-		"deprecated": true
-	},
-	"static_neutral_1500_inverted_press": {
-		"rgba": "rgba(160, 161, 169, 1)",
-		"hex": "#a0a1a9",
-		"figma": "static_neutral_inverted/1500/press",
-		"web": "--color-static-neutral-1500-inverted-press",
-		"alias": "staticNeutralColor1500InvertedPress",
-		"deprecated": true
-	},
-	"static_neutral_1500_press": {
-		"rgba": "rgba(95, 95, 102, 1)",
-		"hex": "#5f5f66",
-		"figma": "static_neutral/1500/press",
-		"web": "--color-static-neutral-1500-press",
-		"alias": "staticNeutralColor1500Press",
-		"deprecated": true
 	},
 	"static_neutral_200": {
 		"rgba": "rgba(237, 238, 240, 1)",
@@ -4330,38 +4114,6 @@
 		"figma": "static_neutral-translucent/1300/press",
 		"web": "--color-static-neutral-translucent-1300-press",
 		"alias": "staticNeutralTranslucentColor1300Press"
-	},
-	"static_neutral_translucent_1500_hover": {
-		"rgba": "rgba(2, 2, 10, 0.76)",
-		"hex": "#c202020a",
-		"figma": "static_neutral-translucent/1500/hover",
-		"web": "--color-static-neutral-translucent-1500-hover",
-		"alias": "staticNeutralTranslucentColor1500Hover",
-		"deprecated": true
-	},
-	"static_neutral_translucent_1500_inverted_hover": {
-		"rgba": "rgba(243, 245, 254, 0.75)",
-		"hex": "#bff3f5fe",
-		"figma": "static_neutral-translucent_inverted/1500/hover",
-		"web": "--color-static-neutral-translucent-1500-inverted-hover",
-		"alias": "staticNeutralTranslucentColor1500InvertedHover",
-		"deprecated": true
-	},
-	"static_neutral_translucent_1500_inverted_press": {
-		"rgba": "rgba(239, 240, 252, 0.65)",
-		"hex": "#a6eff0fc",
-		"figma": "static_neutral-translucent_inverted/1500/press",
-		"web": "--color-static-neutral-translucent-1500-inverted-press",
-		"alias": "staticNeutralTranslucentColor1500InvertedPress",
-		"deprecated": true
-	},
-	"static_neutral_translucent_1500_press": {
-		"rgba": "rgba(1, 1, 12, 0.63)",
-		"hex": "#a101010c",
-		"figma": "static_neutral-translucent/1500/press",
-		"web": "--color-static-neutral-translucent-1500-press",
-		"alias": "staticNeutralTranslucentColor1500Press",
-		"deprecated": true
 	},
 	"static_neutral_translucent_200": {
 		"rgba": "rgba(30, 43, 68, 0.08)",
@@ -4916,14 +4668,6 @@
 		"web": "--color-static-text-primary",
 		"alias": "staticTextColorPrimary"
 	},
-	"static_text_primary_dark": {
-		"rgba": "rgba(14, 14, 14, 1)",
-		"hex": "#0e0e0e",
-		"figma": "static/text-dark/primary",
-		"alias": "staticTextColorPrimaryDark",
-		"web": "--color-static-text-primary-dark",
-		"deprecated": true
-	},
 	"static_text_primary_hover": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
 		"hex": "#a101010c",
@@ -4951,14 +4695,6 @@
 		"figma": "static_text_inverted/primary/press",
 		"web": "--color-static-text-primary-inverted-press",
 		"alias": "staticTextColorPrimaryInvertedPress"
-	},
-	"static_text_primary_light": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "static/text-light/primary",
-		"alias": "staticTextColorPrimaryLight",
-		"web": "--color-static-text-primary-light",
-		"deprecated": true
 	},
 	"static_text_primary_press": {
 		"rgba": "rgba(4, 4, 19, 0.55)",
@@ -4988,14 +4724,6 @@
 		"web": "--color-static-text-secondary",
 		"alias": "staticTextColorSecondary"
 	},
-	"static_text_secondary_dark": {
-		"rgba": "rgba(4, 4, 19, 0.55)",
-		"hex": "#8c040413",
-		"figma": "static/text-dark/secondary",
-		"alias": "staticTextColorSecondaryDark",
-		"web": "--color-static-text-secondary-dark",
-		"deprecated": true
-	},
 	"static_text_secondary_hover": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
 		"hex": "#a101010c",
@@ -5024,14 +4752,6 @@
 		"web": "--color-static-text-secondary-inverted-press",
 		"alias": "staticTextColorSecondaryInvertedPress"
 	},
-	"static_text_secondary_light": {
-		"rgba": "rgba(238, 238, 251, 0.55)",
-		"hex": "#8ceeeefb",
-		"figma": "static/text-light/secondary",
-		"alias": "staticTextColorSecondaryLight",
-		"web": "--color-static-text-secondary-light",
-		"deprecated": true
-	},
 	"static_text_secondary_press": {
 		"rgba": "rgba(0, 0, 10, 0.71)",
 		"hex": "#b500000a",
@@ -5045,14 +4765,6 @@
 		"figma": "static_text/tertiary",
 		"web": "--color-static-text-tertiary",
 		"alias": "staticTextColorTertiary"
-	},
-	"static_text_tertiary_dark": {
-		"rgba": "rgba(5, 8, 29, 0.38)",
-		"hex": "#6105081d",
-		"figma": "static/text-dark/tertiary",
-		"alias": "staticTextColorTertiaryDark",
-		"web": "--color-static-text-tertiary-dark",
-		"deprecated": true
 	},
 	"static_text_tertiary_hover": {
 		"rgba": "rgba(4, 4, 21, 0.47)",
@@ -5081,14 +4793,6 @@
 		"figma": "static_text_inverted/tertiary/press",
 		"web": "--color-static-text-tertiary-inverted-press",
 		"alias": "staticTextColorTertiaryInvertedPress"
-	},
-	"static_text_tertiary_light": {
-		"rgba": "rgba(233, 233, 250, 0.37)",
-		"hex": "#5ee9e9fa",
-		"figma": "static/text-light/tertiary",
-		"alias": "staticTextColorTertiaryLight",
-		"web": "--color-static-text-tertiary-light",
-		"deprecated": true
 	},
 	"static_text_tertiary_press": {
 		"rgba": "rgba(4, 4, 19, 0.55)",
@@ -5488,6 +5192,86 @@
 		"hex": "#b8b9c0",
 		"alias": "graphicColorTertiaryInverted",
 		"web": "--color-dark-graphic-tertiary-inverted"
+	},
+	"dark_neutral_1500": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "neutral/1500",
+		"web": "--color-dark-neutral-1500",
+		"alias": "neutralColor1500",
+		"deprecated": true
+	},
+	"dark_neutral_1500_hover": {
+		"rgba": "rgba(186, 187, 194, 1)",
+		"hex": "#babbc2",
+		"figma": "neutral/1500/hover",
+		"web": "--color-dark-neutral-1500-hover",
+		"alias": "neutralColor1500Hover",
+		"deprecated": true
+	},
+	"dark_neutral_1500_inverted": {
+		"rgba": "rgba(18, 18, 19, 1)",
+		"hex": "#121213",
+		"figma": "neutral_inverted/1500",
+		"web": "--color-dark-neutral-1500-inverted",
+		"alias": "neutralColor1500Inverted",
+		"deprecated": true
+	},
+	"dark_neutral_1500_inverted_hover": {
+		"rgba": "rgba(63, 63, 69, 1)",
+		"hex": "#3f3f45",
+		"figma": "neutral_inverted/1500/hover",
+		"web": "--color-dark-neutral-1500-inverted-hover",
+		"alias": "neutralColor1500InvertedHover",
+		"deprecated": true
+	},
+	"dark_neutral_1500_inverted_press": {
+		"rgba": "rgba(95, 95, 102, 1)",
+		"hex": "#5f5f66",
+		"figma": "neutral_inverted/1500/press",
+		"web": "--color-dark-neutral-1500-inverted-press",
+		"alias": "neutralColor1500InvertedPress",
+		"deprecated": true
+	},
+	"dark_neutral_1500_press": {
+		"rgba": "rgba(160, 161, 169, 1)",
+		"hex": "#a0a1a9",
+		"figma": "neutral/1500/press",
+		"web": "--color-dark-neutral-1500-press",
+		"alias": "neutralColor1500Press",
+		"deprecated": true
+	},
+	"dark_neutral_translucent_1500_hover": {
+		"rgba": "rgba(243, 245, 254, 0.75)",
+		"hex": "#bff3f5fe",
+		"figma": "neutral-translucent/1500/hover",
+		"web": "--color-dark-neutral-translucent-1500-hover",
+		"alias": "neutralTranslucentColor1500Hover",
+		"deprecated": true
+	},
+	"dark_neutral_translucent_1500_inverted_hover": {
+		"rgba": "rgba(2, 2, 10, 0.76)",
+		"hex": "#c202020a",
+		"figma": "neutral-translucent_inverted/1500/hover",
+		"web": "--color-dark-neutral-translucent-1500-inverted-hover",
+		"alias": "neutralTranslucentColor1500InvertedHover",
+		"deprecated": true
+	},
+	"dark_neutral_translucent_1500_inverted_press": {
+		"rgba": "rgba(1, 1, 12, 0.63)",
+		"hex": "#a101010c",
+		"figma": "neutral-translucent_inverted/1500/press",
+		"web": "--color-dark-neutral-translucent-1500-inverted-press",
+		"alias": "neutralTranslucentColor1500InvertedPress",
+		"deprecated": true
+	},
+	"dark_neutral_translucent_1500_press": {
+		"rgba": "rgba(239, 240, 252, 0.65)",
+		"hex": "#a6eff0fc",
+		"figma": "neutral-translucent/1500/press",
+		"web": "--color-dark-neutral-translucent-1500-press",
+		"alias": "neutralTranslucentColor1500Press",
+		"deprecated": true
 	},
 	"dark_specialbg_component": {
 		"deprecated": true,
@@ -5986,6 +5770,86 @@
 		"alias": "graphicColorTertiaryInverted",
 		"web": "--color-light-graphic-tertiary-inverted"
 	},
+	"light_neutral_1500": {
+		"rgba": "rgba(18, 18, 19, 1)",
+		"hex": "#121213",
+		"figma": "neutral/1500",
+		"web": "--color-light-neutral-1500",
+		"alias": "neutralColor1500",
+		"deprecated": true
+	},
+	"light_neutral_1500_hover": {
+		"rgba": "rgba(63, 63, 69, 1)",
+		"hex": "#3f3f45",
+		"figma": "neutral/1500/hover",
+		"web": "--color-light-neutral-1500-hover",
+		"alias": "neutralColor1500Hover",
+		"deprecated": true
+	},
+	"light_neutral_1500_inverted": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "neutral_inverted/1500",
+		"web": "--color-light-neutral-1500-inverted",
+		"alias": "neutralColor1500Inverted",
+		"deprecated": true
+	},
+	"light_neutral_1500_inverted_hover": {
+		"rgba": "rgba(186, 187, 194, 1)",
+		"hex": "#babbc2",
+		"figma": "neutral_inverted/1500/hover",
+		"web": "--color-light-neutral-1500-inverted-hover",
+		"alias": "neutralColor1500InvertedHover",
+		"deprecated": true
+	},
+	"light_neutral_1500_inverted_press": {
+		"rgba": "rgba(160, 161, 169, 1)",
+		"hex": "#a0a1a9",
+		"figma": "neutral_inverted/1500/press",
+		"web": "--color-light-neutral-1500-inverted-press",
+		"alias": "neutralColor1500InvertedPress",
+		"deprecated": true
+	},
+	"light_neutral_1500_press": {
+		"rgba": "rgba(95, 95, 102, 1)",
+		"hex": "#5f5f66",
+		"figma": "neutral/1500/press",
+		"web": "--color-light-neutral-1500-press",
+		"alias": "neutralColor1500Press",
+		"deprecated": true
+	},
+	"light_neutral_translucent_1500_hover": {
+		"rgba": "rgba(2, 2, 10, 0.76)",
+		"hex": "#c202020a",
+		"figma": "neutral-translucent/1500/hover",
+		"web": "--color-light-neutral-translucent-1500-hover",
+		"alias": "neutralTranslucentColor1500Hover",
+		"deprecated": true
+	},
+	"light_neutral_translucent_1500_inverted_hover": {
+		"rgba": "rgba(243, 245, 254, 0.75)",
+		"hex": "#bff3f5fe",
+		"figma": "neutral-translucent_inverted/1500/hover",
+		"web": "--color-light-neutral-translucent-1500-inverted-hover",
+		"alias": "neutralTranslucentColor1500InvertedHover",
+		"deprecated": true
+	},
+	"light_neutral_translucent_1500_inverted_press": {
+		"rgba": "rgba(239, 240, 252, 0.65)",
+		"hex": "#a6eff0fc",
+		"figma": "neutral-translucent_inverted/1500/press",
+		"web": "--color-light-neutral-translucent-1500-inverted-press",
+		"alias": "neutralTranslucentColor1500InvertedPress",
+		"deprecated": true
+	},
+	"light_neutral_translucent_1500_press": {
+		"rgba": "rgba(1, 1, 12, 0.63)",
+		"hex": "#a101010c",
+		"figma": "neutral-translucent/1500/press",
+		"web": "--color-light-neutral-translucent-1500-press",
+		"alias": "neutralTranslucentColor1500Press",
+		"deprecated": true
+	},
 	"light_specialbg_component": {
 		"deprecated": true,
 		"rgba": "rgba(11, 31, 53, 0.07)",
@@ -6169,6 +6033,14 @@
 		"deprecated": true,
 		"web": "--color-static-bg-neutral-light"
 	},
+	"static_bg_primary_dark": {
+		"rgba": "rgba(18, 18, 19, 1)",
+		"hex": "#121213",
+		"figma": "static/bg-dark/primary",
+		"alias": "staticBackgroundColorPrimaryDark",
+		"web": "--color-static-bg-primary-dark",
+		"deprecated": true
+	},
 	"static_bg_primary_light": {
 		"deprecated": true,
 		"rgba": "rgba(255, 255, 255, 1)",
@@ -6257,6 +6129,86 @@
 		"alias": "staticGraphicColorLight",
 		"web": "--color-static-graphic-light"
 	},
+	"static_neutral_1500": {
+		"rgba": "rgba(18, 18, 19, 1)",
+		"hex": "#121213",
+		"figma": "static_neutral/1500",
+		"web": "--color-static-neutral-1500",
+		"alias": "staticNeutralColor1500",
+		"deprecated": true
+	},
+	"static_neutral_1500_hover": {
+		"rgba": "rgba(63, 63, 69, 1)",
+		"hex": "#3f3f45",
+		"figma": "static_neutral/1500/hover",
+		"web": "--color-static-neutral-1500-hover",
+		"alias": "staticNeutralColor1500Hover",
+		"deprecated": true
+	},
+	"static_neutral_1500_inverted": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "static_neutral_inverted/1500",
+		"web": "--color-static-neutral-1500-inverted",
+		"alias": "staticNeutralColor1500Inverted",
+		"deprecated": true
+	},
+	"static_neutral_1500_inverted_hover": {
+		"rgba": "rgba(186, 187, 194, 1)",
+		"hex": "#babbc2",
+		"figma": "static_neutral_inverted/1500/hover",
+		"web": "--color-static-neutral-1500-inverted-hover",
+		"alias": "staticNeutralColor1500InvertedHover",
+		"deprecated": true
+	},
+	"static_neutral_1500_inverted_press": {
+		"rgba": "rgba(160, 161, 169, 1)",
+		"hex": "#a0a1a9",
+		"figma": "static_neutral_inverted/1500/press",
+		"web": "--color-static-neutral-1500-inverted-press",
+		"alias": "staticNeutralColor1500InvertedPress",
+		"deprecated": true
+	},
+	"static_neutral_1500_press": {
+		"rgba": "rgba(95, 95, 102, 1)",
+		"hex": "#5f5f66",
+		"figma": "static_neutral/1500/press",
+		"web": "--color-static-neutral-1500-press",
+		"alias": "staticNeutralColor1500Press",
+		"deprecated": true
+	},
+	"static_neutral_translucent_1500_hover": {
+		"rgba": "rgba(2, 2, 10, 0.76)",
+		"hex": "#c202020a",
+		"figma": "static_neutral-translucent/1500/hover",
+		"web": "--color-static-neutral-translucent-1500-hover",
+		"alias": "staticNeutralTranslucentColor1500Hover",
+		"deprecated": true
+	},
+	"static_neutral_translucent_1500_inverted_hover": {
+		"rgba": "rgba(243, 245, 254, 0.75)",
+		"hex": "#bff3f5fe",
+		"figma": "static_neutral-translucent_inverted/1500/hover",
+		"web": "--color-static-neutral-translucent-1500-inverted-hover",
+		"alias": "staticNeutralTranslucentColor1500InvertedHover",
+		"deprecated": true
+	},
+	"static_neutral_translucent_1500_inverted_press": {
+		"rgba": "rgba(239, 240, 252, 0.65)",
+		"hex": "#a6eff0fc",
+		"figma": "static_neutral-translucent_inverted/1500/press",
+		"web": "--color-static-neutral-translucent-1500-inverted-press",
+		"alias": "staticNeutralTranslucentColor1500InvertedPress",
+		"deprecated": true
+	},
+	"static_neutral_translucent_1500_press": {
+		"rgba": "rgba(1, 1, 12, 0.63)",
+		"hex": "#a101010c",
+		"figma": "static_neutral-translucent/1500/press",
+		"web": "--color-static-neutral-translucent-1500-press",
+		"alias": "staticNeutralTranslucentColor1500Press",
+		"deprecated": true
+	},
 	"static_text_accent": {
 		"deprecated": true,
 		"rgba": "rgba(239, 49, 36, 1)",
@@ -6265,12 +6217,44 @@
 		"alias": "staticTextColorAccent",
 		"web": "--color-static-text-accent"
 	},
+	"static_text_primary_dark": {
+		"rgba": "rgba(14, 14, 14, 1)",
+		"hex": "#0e0e0e",
+		"figma": "static/text-dark/primary",
+		"alias": "staticTextColorPrimaryDark",
+		"web": "--color-static-text-primary-dark",
+		"deprecated": true
+	},
+	"static_text_primary_light": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "static/text-light/primary",
+		"alias": "staticTextColorPrimaryLight",
+		"web": "--color-static-text-primary-light",
+		"deprecated": true
+	},
+	"static_text_secondary_dark": {
+		"rgba": "rgba(4, 4, 19, 0.55)",
+		"hex": "#8c040413",
+		"figma": "static/text-dark/secondary",
+		"alias": "staticTextColorSecondaryDark",
+		"web": "--color-static-text-secondary-dark",
+		"deprecated": true
+	},
 	"static_text_secondary_dark_transparent": {
 		"rgba": "rgba(3, 3, 16, 0.56)",
 		"hex": "#8f030310",
 		"alias": "staticTextColorSecondaryDarkTransparent",
 		"deprecated": true,
 		"web": "--color-static-text-secondary-dark-transparent"
+	},
+	"static_text_secondary_light": {
+		"rgba": "rgba(238, 238, 251, 0.55)",
+		"hex": "#8ceeeefb",
+		"figma": "static/text-light/secondary",
+		"alias": "staticTextColorSecondaryLight",
+		"web": "--color-static-text-secondary-light",
+		"deprecated": true
 	},
 	"static_text_secondary_light_transparent": {
 		"rgba": "rgba(235, 235, 245, 0.6)",
@@ -6279,12 +6263,28 @@
 		"deprecated": true,
 		"web": "--color-static-text-secondary-light-transparent"
 	},
+	"static_text_tertiary_dark": {
+		"rgba": "rgba(5, 8, 29, 0.38)",
+		"hex": "#6105081d",
+		"figma": "static/text-dark/tertiary",
+		"alias": "staticTextColorTertiaryDark",
+		"web": "--color-static-text-tertiary-dark",
+		"deprecated": true
+	},
 	"static_text_tertiary_dark_transparent": {
 		"rgba": "rgba(1, 1, 18, 0.41)",
 		"hex": "#69010112",
 		"alias": "staticTextColorTertiaryDarkTransparent",
 		"deprecated": true,
 		"web": "--color-static-text-tertiary-dark-transparent"
+	},
+	"static_text_tertiary_light": {
+		"rgba": "rgba(233, 233, 250, 0.37)",
+		"hex": "#5ee9e9fa",
+		"figma": "static/text-light/tertiary",
+		"alias": "staticTextColorTertiaryLight",
+		"web": "--color-static-text-tertiary-light",
+		"deprecated": true
 	},
 	"static_text_tertiary_light_transparent": {
 		"rgba": "rgba(235, 235, 245, 0.3)",

--- a/styles/colors_bluetint.json
+++ b/styles/colors_bluetint.json
@@ -382,42 +382,48 @@
 		"hex": "#ffffff",
 		"figma": "neutral/1500",
 		"web": "--color-dark-neutral-1500",
-		"alias": "neutralColor1500"
+		"alias": "neutralColor1500",
+		"deprecated": true
 	},
 	"dark_neutral_1500_hover": {
 		"rgba": "rgba(186, 187, 194, 1)",
 		"hex": "#babbc2",
 		"figma": "neutral/1500/hover",
 		"web": "--color-dark-neutral-1500-hover",
-		"alias": "neutralColor1500Hover"
+		"alias": "neutralColor1500Hover",
+		"deprecated": true
 	},
 	"dark_neutral_1500_inverted": {
 		"rgba": "rgba(18, 18, 19, 1)",
 		"hex": "#121213",
 		"figma": "neutral_inverted/1500",
 		"web": "--color-dark-neutral-1500-inverted",
-		"alias": "neutralColor1500Inverted"
+		"alias": "neutralColor1500Inverted",
+		"deprecated": true
 	},
 	"dark_neutral_1500_inverted_hover": {
 		"rgba": "rgba(63, 63, 69, 1)",
 		"hex": "#3f3f45",
 		"figma": "neutral_inverted/1500/hover",
 		"web": "--color-dark-neutral-1500-inverted-hover",
-		"alias": "neutralColor1500InvertedHover"
+		"alias": "neutralColor1500InvertedHover",
+		"deprecated": true
 	},
 	"dark_neutral_1500_inverted_press": {
 		"rgba": "rgba(95, 95, 102, 1)",
 		"hex": "#5f5f66",
 		"figma": "neutral_inverted/1500/press",
 		"web": "--color-dark-neutral-1500-inverted-press",
-		"alias": "neutralColor1500InvertedPress"
+		"alias": "neutralColor1500InvertedPress",
+		"deprecated": true
 	},
 	"dark_neutral_1500_press": {
 		"rgba": "rgba(160, 161, 169, 1)",
 		"hex": "#a0a1a9",
 		"figma": "neutral/1500/press",
 		"web": "--color-dark-neutral-1500-press",
-		"alias": "neutralColor1500Press"
+		"alias": "neutralColor1500Press",
+		"deprecated": true
 	},
 	"dark_neutral_200": {
 		"rgba": "rgba(33, 33, 36, 1)",
@@ -760,28 +766,32 @@
 		"hex": "#bff3f5fe",
 		"figma": "neutral-translucent/1500/hover",
 		"web": "--color-dark-neutral-translucent-1500-hover",
-		"alias": "neutralTranslucentColor1500Hover"
+		"alias": "neutralTranslucentColor1500Hover",
+		"deprecated": true
 	},
 	"dark_neutral_translucent_1500_inverted_hover": {
 		"rgba": "rgba(2, 2, 10, 0.76)",
 		"hex": "#c202020a",
 		"figma": "neutral-translucent_inverted/1500/hover",
 		"web": "--color-dark-neutral-translucent-1500-inverted-hover",
-		"alias": "neutralTranslucentColor1500InvertedHover"
+		"alias": "neutralTranslucentColor1500InvertedHover",
+		"deprecated": true
 	},
 	"dark_neutral_translucent_1500_inverted_press": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
 		"hex": "#a101010c",
 		"figma": "neutral-translucent_inverted/1500/press",
 		"web": "--color-dark-neutral-translucent-1500-inverted-press",
-		"alias": "neutralTranslucentColor1500InvertedPress"
+		"alias": "neutralTranslucentColor1500InvertedPress",
+		"deprecated": true
 	},
 	"dark_neutral_translucent_1500_press": {
 		"rgba": "rgba(239, 240, 252, 0.65)",
 		"hex": "#a6eff0fc",
 		"figma": "neutral-translucent/1500/press",
 		"web": "--color-dark-neutral-translucent-1500-press",
-		"alias": "neutralTranslucentColor1500Press"
+		"alias": "neutralTranslucentColor1500Press",
+		"deprecated": true
 	},
 	"dark_neutral_translucent_200": {
 		"rgba": "rgba(225, 225, 248, 0.09)",
@@ -2237,42 +2247,48 @@
 		"hex": "#121213",
 		"figma": "neutral/1500",
 		"web": "--color-light-neutral-1500",
-		"alias": "neutralColor1500"
+		"alias": "neutralColor1500",
+		"deprecated": true
 	},
 	"light_neutral_1500_hover": {
 		"rgba": "rgba(63, 63, 69, 1)",
 		"hex": "#3f3f45",
 		"figma": "neutral/1500/hover",
 		"web": "--color-light-neutral-1500-hover",
-		"alias": "neutralColor1500Hover"
+		"alias": "neutralColor1500Hover",
+		"deprecated": true
 	},
 	"light_neutral_1500_inverted": {
 		"rgba": "rgba(255, 255, 255, 1)",
 		"hex": "#ffffff",
 		"figma": "neutral_inverted/1500",
 		"web": "--color-light-neutral-1500-inverted",
-		"alias": "neutralColor1500Inverted"
+		"alias": "neutralColor1500Inverted",
+		"deprecated": true
 	},
 	"light_neutral_1500_inverted_hover": {
 		"rgba": "rgba(186, 187, 194, 1)",
 		"hex": "#babbc2",
 		"figma": "neutral_inverted/1500/hover",
 		"web": "--color-light-neutral-1500-inverted-hover",
-		"alias": "neutralColor1500InvertedHover"
+		"alias": "neutralColor1500InvertedHover",
+		"deprecated": true
 	},
 	"light_neutral_1500_inverted_press": {
 		"rgba": "rgba(160, 161, 169, 1)",
 		"hex": "#a0a1a9",
 		"figma": "neutral_inverted/1500/press",
 		"web": "--color-light-neutral-1500-inverted-press",
-		"alias": "neutralColor1500InvertedPress"
+		"alias": "neutralColor1500InvertedPress",
+		"deprecated": true
 	},
 	"light_neutral_1500_press": {
 		"rgba": "rgba(95, 95, 102, 1)",
 		"hex": "#5f5f66",
 		"figma": "neutral/1500/press",
 		"web": "--color-light-neutral-1500-press",
-		"alias": "neutralColor1500Press"
+		"alias": "neutralColor1500Press",
+		"deprecated": true
 	},
 	"light_neutral_200": {
 		"rgba": "rgba(237, 238, 240, 1)",
@@ -2615,28 +2631,32 @@
 		"hex": "#c202020a",
 		"figma": "neutral-translucent/1500/hover",
 		"web": "--color-light-neutral-translucent-1500-hover",
-		"alias": "neutralTranslucentColor1500Hover"
+		"alias": "neutralTranslucentColor1500Hover",
+		"deprecated": true
 	},
 	"light_neutral_translucent_1500_inverted_hover": {
 		"rgba": "rgba(243, 245, 254, 0.75)",
 		"hex": "#bff3f5fe",
 		"figma": "neutral-translucent_inverted/1500/hover",
 		"web": "--color-light-neutral-translucent-1500-inverted-hover",
-		"alias": "neutralTranslucentColor1500InvertedHover"
+		"alias": "neutralTranslucentColor1500InvertedHover",
+		"deprecated": true
 	},
 	"light_neutral_translucent_1500_inverted_press": {
 		"rgba": "rgba(239, 240, 252, 0.65)",
 		"hex": "#a6eff0fc",
 		"figma": "neutral-translucent_inverted/1500/press",
 		"web": "--color-light-neutral-translucent-1500-inverted-press",
-		"alias": "neutralTranslucentColor1500InvertedPress"
+		"alias": "neutralTranslucentColor1500InvertedPress",
+		"deprecated": true
 	},
 	"light_neutral_translucent_1500_press": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
 		"hex": "#a101010c",
 		"figma": "neutral-translucent/1500/press",
 		"web": "--color-light-neutral-translucent-1500-press",
-		"alias": "neutralTranslucentColor1500Press"
+		"alias": "neutralTranslucentColor1500Press",
+		"deprecated": true
 	},
 	"light_neutral_translucent_200": {
 		"rgba": "rgba(30, 43, 68, 0.08)",
@@ -3798,7 +3818,8 @@
 		"hex": "#121213",
 		"figma": "static/bg-dark/primary",
 		"alias": "staticBackgroundColorPrimaryDark",
-		"web": "--color-static-bg-primary-dark"
+		"web": "--color-static-bg-primary-dark",
+		"deprecated": true
 	},
 	"static_neutral_0": {
 		"rgba": "rgba(255, 255, 255, 1)",
@@ -3931,42 +3952,48 @@
 		"hex": "#121213",
 		"figma": "static_neutral/1500",
 		"web": "--color-static-neutral-1500",
-		"alias": "staticNeutralColor1500"
+		"alias": "staticNeutralColor1500",
+		"deprecated": true
 	},
 	"static_neutral_1500_hover": {
 		"rgba": "rgba(63, 63, 69, 1)",
 		"hex": "#3f3f45",
 		"figma": "static_neutral/1500/hover",
 		"web": "--color-static-neutral-1500-hover",
-		"alias": "staticNeutralColor1500Hover"
+		"alias": "staticNeutralColor1500Hover",
+		"deprecated": true
 	},
 	"static_neutral_1500_inverted": {
 		"rgba": "rgba(255, 255, 255, 1)",
 		"hex": "#ffffff",
 		"figma": "static_neutral_inverted/1500",
 		"web": "--color-static-neutral-1500-inverted",
-		"alias": "staticNeutralColor1500Inverted"
+		"alias": "staticNeutralColor1500Inverted",
+		"deprecated": true
 	},
 	"static_neutral_1500_inverted_hover": {
 		"rgba": "rgba(186, 187, 194, 1)",
 		"hex": "#babbc2",
 		"figma": "static_neutral_inverted/1500/hover",
 		"web": "--color-static-neutral-1500-inverted-hover",
-		"alias": "staticNeutralColor1500InvertedHover"
+		"alias": "staticNeutralColor1500InvertedHover",
+		"deprecated": true
 	},
 	"static_neutral_1500_inverted_press": {
 		"rgba": "rgba(160, 161, 169, 1)",
 		"hex": "#a0a1a9",
 		"figma": "static_neutral_inverted/1500/press",
 		"web": "--color-static-neutral-1500-inverted-press",
-		"alias": "staticNeutralColor1500InvertedPress"
+		"alias": "staticNeutralColor1500InvertedPress",
+		"deprecated": true
 	},
 	"static_neutral_1500_press": {
 		"rgba": "rgba(95, 95, 102, 1)",
 		"hex": "#5f5f66",
 		"figma": "static_neutral/1500/press",
 		"web": "--color-static-neutral-1500-press",
-		"alias": "staticNeutralColor1500Press"
+		"alias": "staticNeutralColor1500Press",
+		"deprecated": true
 	},
 	"static_neutral_200": {
 		"rgba": "rgba(237, 238, 240, 1)",
@@ -4309,28 +4336,32 @@
 		"hex": "#c202020a",
 		"figma": "static_neutral-translucent/1500/hover",
 		"web": "--color-static-neutral-translucent-1500-hover",
-		"alias": "staticNeutralTranslucentColor1500Hover"
+		"alias": "staticNeutralTranslucentColor1500Hover",
+		"deprecated": true
 	},
 	"static_neutral_translucent_1500_inverted_hover": {
 		"rgba": "rgba(243, 245, 254, 0.75)",
 		"hex": "#bff3f5fe",
 		"figma": "static_neutral-translucent_inverted/1500/hover",
 		"web": "--color-static-neutral-translucent-1500-inverted-hover",
-		"alias": "staticNeutralTranslucentColor1500InvertedHover"
+		"alias": "staticNeutralTranslucentColor1500InvertedHover",
+		"deprecated": true
 	},
 	"static_neutral_translucent_1500_inverted_press": {
 		"rgba": "rgba(239, 240, 252, 0.65)",
 		"hex": "#a6eff0fc",
 		"figma": "static_neutral-translucent_inverted/1500/press",
 		"web": "--color-static-neutral-translucent-1500-inverted-press",
-		"alias": "staticNeutralTranslucentColor1500InvertedPress"
+		"alias": "staticNeutralTranslucentColor1500InvertedPress",
+		"deprecated": true
 	},
 	"static_neutral_translucent_1500_press": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
 		"hex": "#a101010c",
 		"figma": "static_neutral-translucent/1500/press",
 		"web": "--color-static-neutral-translucent-1500-press",
-		"alias": "staticNeutralTranslucentColor1500Press"
+		"alias": "staticNeutralTranslucentColor1500Press",
+		"deprecated": true
 	},
 	"static_neutral_translucent_200": {
 		"rgba": "rgba(30, 43, 68, 0.08)",
@@ -4890,7 +4921,8 @@
 		"hex": "#0e0e0e",
 		"figma": "static/text-dark/primary",
 		"alias": "staticTextColorPrimaryDark",
-		"web": "--color-static-text-primary-dark"
+		"web": "--color-static-text-primary-dark",
+		"deprecated": true
 	},
 	"static_text_primary_hover": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
@@ -4925,7 +4957,8 @@
 		"hex": "#ffffff",
 		"figma": "static/text-light/primary",
 		"alias": "staticTextColorPrimaryLight",
-		"web": "--color-static-text-primary-light"
+		"web": "--color-static-text-primary-light",
+		"deprecated": true
 	},
 	"static_text_primary_press": {
 		"rgba": "rgba(4, 4, 19, 0.55)",
@@ -4960,7 +4993,8 @@
 		"hex": "#8c040413",
 		"figma": "static/text-dark/secondary",
 		"alias": "staticTextColorSecondaryDark",
-		"web": "--color-static-text-secondary-dark"
+		"web": "--color-static-text-secondary-dark",
+		"deprecated": true
 	},
 	"static_text_secondary_hover": {
 		"rgba": "rgba(1, 1, 12, 0.63)",
@@ -4995,7 +5029,8 @@
 		"hex": "#8ceeeefb",
 		"figma": "static/text-light/secondary",
 		"alias": "staticTextColorSecondaryLight",
-		"web": "--color-static-text-secondary-light"
+		"web": "--color-static-text-secondary-light",
+		"deprecated": true
 	},
 	"static_text_secondary_press": {
 		"rgba": "rgba(0, 0, 10, 0.71)",
@@ -5016,7 +5051,8 @@
 		"hex": "#6105081d",
 		"figma": "static/text-dark/tertiary",
 		"alias": "staticTextColorTertiaryDark",
-		"web": "--color-static-text-tertiary-dark"
+		"web": "--color-static-text-tertiary-dark",
+		"deprecated": true
 	},
 	"static_text_tertiary_hover": {
 		"rgba": "rgba(4, 4, 21, 0.47)",
@@ -5051,7 +5087,8 @@
 		"hex": "#5ee9e9fa",
 		"figma": "static/text-light/tertiary",
 		"alias": "staticTextColorTertiaryLight",
-		"web": "--color-static-text-tertiary-light"
+		"web": "--color-static-text-tertiary-light",
+		"deprecated": true
 	},
 	"static_text_tertiary_press": {
 		"rgba": "rgba(4, 4, 19, 0.55)",

--- a/styles/colors_brand.json
+++ b/styles/colors_brand.json
@@ -7,8 +7,8 @@
 		"alias": "staticBrandColorBlack"
 	},
 	"static_brand_blue": {
-		"rgba": "rgba(0, 86, 255, 1)",
-		"hex": "#0056ff",
+		"rgba": "rgba(0, 87, 255, 1)",
+		"hex": "#0057ff",
 		"figma": "static_brand/blue",
 		"web": "--color-static-brand-blue",
 		"alias": "staticBrandColorBlue"

--- a/styles/colors_go.json
+++ b/styles/colors_go.json
@@ -1,51 +1,51 @@
 {
-  "dark_go_lilac": {
-    "rgba": "rgba(43, 33, 58, 1)",
-    "hex": "#2b213a",
-    "figma": "go/lilac",
-    "web": "--color-dark-go-lilac",
-    "alias": "goColorLilac"
-  },
-  "dark_go_violet": {
-    "rgba": "rgba(123, 84, 235, 1)",
-    "hex": "#7b54eb",
-    "figma": "go/violet",
-    "web": "--color-dark-go-violet",
-    "alias": "goColorViolet"
-  },
-  "light_go_lilac": {
-    "rgba": "rgba(246, 235, 255, 1)",
-    "hex": "#f6ebff",
-    "figma": "go/lilac",
-    "web": "--color-light-go-lilac",
-    "alias": "goColorLilac"
-  },
-  "light_go_violet": {
-    "rgba": "rgba(122, 56, 224, 1)",
-    "hex": "#7a38e0",
-    "figma": "go/violet",
-    "web": "--color-light-go-violet",
-    "alias": "goColorViolet"
-  },
-  "static_go_lime": {
-    "rgba": "rgba(144, 233, 120, 1)",
-    "hex": "#90e978",
-    "figma": "static_go/lime",
-    "web": "--color-static-go-lime",
-    "alias": "staticGoColorLime"
-  },
-  "static_go_toxic": {
-    "rgba": "rgba(100, 227, 75, 1)",
-    "hex": "#64e34b",
-    "figma": "static_go/toxic",
-    "web": "--color-static-go-toxic",
-    "alias": "staticGoColorToxic"
-  },
-  "static_go_violet": {
-    "rgba": "rgba(122, 56, 224, 1)",
-    "hex": "#7a38e0",
-    "figma": "static_go/violet",
-    "web": "--color-static-go-violet",
-    "alias": "staticGoColorViolet"
-  }
+	"dark_go_lilac": {
+		"rgba": "rgba(43, 33, 58, 1)",
+		"hex": "#2b213a",
+		"figma": "go/lilac",
+		"web": "--color-dark-go-lilac",
+		"alias": "goColorLilac"
+	},
+	"dark_go_violet": {
+		"rgba": "rgba(123, 84, 235, 1)",
+		"hex": "#7b54eb",
+		"figma": "go/violet",
+		"web": "--color-dark-go-violet",
+		"alias": "goColorViolet"
+	},
+	"light_go_lilac": {
+		"rgba": "rgba(246, 235, 255, 1)",
+		"hex": "#f6ebff",
+		"figma": "go/lilac",
+		"web": "--color-light-go-lilac",
+		"alias": "goColorLilac"
+	},
+	"light_go_violet": {
+		"rgba": "rgba(122, 56, 224, 1)",
+		"hex": "#7a38e0",
+		"figma": "go/violet",
+		"web": "--color-light-go-violet",
+		"alias": "goColorViolet"
+	},
+	"static_go_lime": {
+		"rgba": "rgba(144, 233, 120, 1)",
+		"hex": "#90e978",
+		"figma": "static_go/lime",
+		"web": "--color-static-go-lime",
+		"alias": "staticGoColorLime"
+	},
+	"static_go_toxic": {
+		"rgba": "rgba(100, 227, 75, 1)",
+		"hex": "#64e34b",
+		"figma": "static_go/toxic",
+		"web": "--color-static-go-toxic",
+		"alias": "staticGoColorToxic"
+	},
+	"static_go_violet": {
+		"rgba": "rgba(122, 56, 224, 1)",
+		"hex": "#7a38e0",
+		"figma": "static_go/violet",
+		"web": "--color-static-go-violet",
+		"alias": "staticGoColorViolet"
+	}
 }

--- a/styles/colors_monochrome.json
+++ b/styles/colors_monochrome.json
@@ -1,858 +1,4 @@
 {
-	"static_monochrome_black_2": {
-		"rgba": "rgba(0, 0, 0, 0.02)",
-		"hex": "#05000000",
-		"figma": "static_monochrome-black/2",
-		"web": "--color-static-monochrome-black-2",
-		"alias": "staticMonochromeBlackColor2"
-	},
-	"static_monochrome_black_4": {
-		"rgba": "rgba(0, 0, 0, 0.04)",
-		"hex": "#0a000000",
-		"figma": "static_monochrome-black/4",
-		"web": "--color-static-monochrome-black-4",
-		"alias": "staticMonochromeBlackColor4"
-	},
-	"static_monochrome_black_6": {
-		"rgba": "rgba(0, 0, 0, 0.06)",
-		"hex": "#0f000000",
-		"figma": "static_monochrome-black/6",
-		"web": "--color-static-monochrome-black-6",
-		"alias": "staticMonochromeBlackColor6"
-	},
-	"static_monochrome_black_8": {
-		"rgba": "rgba(0, 0, 0, 0.08)",
-		"hex": "#14000000",
-		"figma": "static_monochrome-black/8",
-		"web": "--color-static-monochrome-black-8",
-		"alias": "staticMonochromeBlackColor8"
-	},
-	"static_monochrome_black_10": {
-		"rgba": "rgba(0, 0, 0, 0.1)",
-		"hex": "#1a000000",
-		"figma": "static_monochrome-black/10",
-		"web": "--color-static-monochrome-black-10",
-		"alias": "staticMonochromeBlackColor10"
-	},
-	"static_monochrome_black_12": {
-		"rgba": "rgba(0, 0, 0, 0.12)",
-		"hex": "#1f000000",
-		"figma": "static_monochrome-black/12",
-		"web": "--color-static-monochrome-black-12",
-		"alias": "staticMonochromeBlackColor12"
-	},
-	"static_monochrome_black_16": {
-		"rgba": "rgba(0, 0, 0, 0.16)",
-		"hex": "#29000000",
-		"figma": "static_monochrome-black/16",
-		"web": "--color-static-monochrome-black-16",
-		"alias": "staticMonochromeBlackColor16"
-	},
-	"static_monochrome_black_20": {
-		"rgba": "rgba(0, 0, 0, 0.2)",
-		"hex": "#33000000",
-		"figma": "static_monochrome-black/20",
-		"web": "--color-static-monochrome-black-20",
-		"alias": "staticMonochromeBlackColor20"
-	},
-	"static_monochrome_black_24": {
-		"rgba": "rgba(0, 0, 0, 0.24)",
-		"hex": "#3d000000",
-		"figma": "static_monochrome-black/24",
-		"web": "--color-static-monochrome-black-24",
-		"alias": "staticMonochromeBlackColor24"
-	},
-	"static_monochrome_black_32": {
-		"rgba": "rgba(0, 0, 0, 0.32)",
-		"hex": "#52000000",
-		"figma": "static_monochrome-black/32",
-		"web": "--color-static-monochrome-black-32",
-		"alias": "staticMonochromeBlackColor32"
-	},
-	"static_monochrome_black_40": {
-		"rgba": "rgba(0, 0, 0, 0.4)",
-		"hex": "#66000000",
-		"figma": "static_monochrome-black/40",
-		"web": "--color-static-monochrome-black-40",
-		"alias": "staticMonochromeBlackColor40"
-	},
-	"static_monochrome_black_44": {
-		"rgba": "rgba(0, 0, 0, 0.44)",
-		"hex": "#70000000",
-		"figma": "static_monochrome-black/44",
-		"web": "--color-static-monochrome-black-44",
-		"alias": "staticMonochromeBlackColor44"
-	},
-	"static_monochrome_black_48": {
-		"rgba": "rgba(0, 0, 0, 0.48)",
-		"hex": "#7a000000",
-		"figma": "static_monochrome-black/48",
-		"web": "--color-static-monochrome-black-48",
-		"alias": "staticMonochromeBlackColor48"
-	},
-	"static_monochrome_black_56": {
-		"rgba": "rgba(0, 0, 0, 0.56)",
-		"hex": "#8f000000",
-		"figma": "static_monochrome-black/56",
-		"web": "--color-static-monochrome-black-56",
-		"alias": "staticMonochromeBlackColor56"
-	},
-	"static_monochrome_black_64": {
-		"rgba": "rgba(0, 0, 0, 0.64)",
-		"hex": "#a3000000",
-		"figma": "static_monochrome-black/64",
-		"web": "--color-static-monochrome-black-64",
-		"alias": "staticMonochromeBlackColor64"
-	},
-	"static_monochrome_black_72": {
-		"rgba": "rgba(0, 0, 0, 0.72)",
-		"hex": "#b8000000",
-		"figma": "static_monochrome-black/72",
-		"web": "--color-static-monochrome-black-72",
-		"alias": "staticMonochromeBlackColor72"
-	},
-	"static_monochrome_black_80": {
-		"rgba": "rgba(0, 0, 0, 0.8)",
-		"hex": "#cc000000",
-		"figma": "static_monochrome-black/80",
-		"web": "--color-static-monochrome-black-80",
-		"alias": "staticMonochromeBlackColor80"
-	},
-	"static_monochrome_black_88": {
-		"rgba": "rgba(0, 0, 0, 0.88)",
-		"hex": "#e0000000",
-		"figma": "static_monochrome-black/88",
-		"web": "--color-static-monochrome-black-88",
-		"alias": "staticMonochromeBlackColor88"
-	},
-	"static_monochrome_black_100": {
-		"rgba": "rgba(0, 0, 0, 1)",
-		"hex": "#000000",
-		"figma": "static_monochrome-black/100",
-		"web": "--color-static-monochrome-black-100",
-		"alias": "staticMonochromeBlackColor100"
-	},
-	"static_monochrome_white_2": {
-		"rgba": "rgba(255, 255, 255, 0.02)",
-		"hex": "#05ffffff",
-		"figma": "static_monochrome-white/2",
-		"web": "--color-static-monochrome-white-2",
-		"alias": "staticMonochromeWhiteColor2"
-	},
-	"static_monochrome_white_4": {
-		"rgba": "rgba(255, 255, 255, 0.04)",
-		"hex": "#0affffff",
-		"figma": "static_monochrome-white/4",
-		"web": "--color-static-monochrome-white-4",
-		"alias": "staticMonochromeWhiteColor4"
-	},
-	"static_monochrome_white_6": {
-		"rgba": "rgba(255, 255, 255, 0.06)",
-		"hex": "#0fffffff",
-		"figma": "static_monochrome-white/6",
-		"web": "--color-static-monochrome-white-6",
-		"alias": "staticMonochromeWhiteColor6"
-	},
-	"static_monochrome_white_8": {
-		"rgba": "rgba(255, 255, 255, 0.08)",
-		"hex": "#14ffffff",
-		"figma": "static_monochrome-white/8",
-		"web": "--color-static-monochrome-white-8",
-		"alias": "staticMonochromeWhiteColor8"
-	},
-	"static_monochrome_white_10": {
-		"rgba": "rgba(255, 255, 255, 0.1)",
-		"hex": "#1affffff",
-		"figma": "static_monochrome-white/10",
-		"web": "--color-static-monochrome-white-10",
-		"alias": "staticMonochromeWhiteColor10"
-	},
-	"static_monochrome_white_12": {
-		"rgba": "rgba(255, 255, 255, 0.12)",
-		"hex": "#1fffffff",
-		"figma": "static_monochrome-white/12",
-		"web": "--color-static-monochrome-white-12",
-		"alias": "staticMonochromeWhiteColor12"
-	},
-	"static_monochrome_white_16": {
-		"rgba": "rgba(255, 255, 255, 0.16)",
-		"hex": "#29ffffff",
-		"figma": "static_monochrome-white/16",
-		"web": "--color-static-monochrome-white-16",
-		"alias": "staticMonochromeWhiteColor16"
-	},
-	"static_monochrome_white_20": {
-		"rgba": "rgba(255, 255, 255, 0.2)",
-		"hex": "#33ffffff",
-		"figma": "static_monochrome-white/20",
-		"web": "--color-static-monochrome-white-20",
-		"alias": "staticMonochromeWhiteColor20"
-	},
-	"static_monochrome_white_24": {
-		"rgba": "rgba(255, 255, 255, 0.24)",
-		"hex": "#3dffffff",
-		"figma": "static_monochrome-white/24",
-		"web": "--color-static-monochrome-white-24",
-		"alias": "staticMonochromeWhiteColor24"
-	},
-	"static_monochrome_white_32": {
-		"rgba": "rgba(255, 255, 255, 0.32)",
-		"hex": "#52ffffff",
-		"figma": "static_monochrome-white/32",
-		"web": "--color-static-monochrome-white-32",
-		"alias": "staticMonochromeWhiteColor32"
-	},
-	"static_monochrome_white_40": {
-		"rgba": "rgba(255, 255, 255, 0.4)",
-		"hex": "#66ffffff",
-		"figma": "static_monochrome-white/40",
-		"web": "--color-static-monochrome-white-40",
-		"alias": "staticMonochromeWhiteColor40"
-	},
-	"static_monochrome_white_44": {
-		"rgba": "rgba(255, 255, 255, 0.44)",
-		"hex": "#70ffffff",
-		"figma": "static_monochrome-white/44",
-		"web": "--color-static-monochrome-white-44",
-		"alias": "staticMonochromeWhiteColor44"
-	},
-	"static_monochrome_white_48": {
-		"rgba": "rgba(255, 255, 255, 0.48)",
-		"hex": "#7affffff",
-		"figma": "static_monochrome-white/48",
-		"web": "--color-static-monochrome-white-48",
-		"alias": "staticMonochromeWhiteColor48"
-	},
-	"static_monochrome_white_56": {
-		"rgba": "rgba(255, 255, 255, 0.56)",
-		"hex": "#8fffffff",
-		"figma": "static_monochrome-white/56",
-		"web": "--color-static-monochrome-white-56",
-		"alias": "staticMonochromeWhiteColor56"
-	},
-	"static_monochrome_white_64": {
-		"rgba": "rgba(255, 255, 255, 0.64)",
-		"hex": "#a3ffffff",
-		"figma": "static_monochrome-white/64",
-		"web": "--color-static-monochrome-white-64",
-		"alias": "staticMonochromeWhiteColor64"
-	},
-	"static_monochrome_white_72": {
-		"rgba": "rgba(255, 255, 255, 0.72)",
-		"hex": "#b8ffffff",
-		"figma": "static_monochrome-white/72",
-		"web": "--color-static-monochrome-white-72",
-		"alias": "staticMonochromeWhiteColor72"
-	},
-	"static_monochrome_white_80": {
-		"rgba": "rgba(255, 255, 255, 0.8)",
-		"hex": "#ccffffff",
-		"figma": "static_monochrome-white/80",
-		"web": "--color-static-monochrome-white-80",
-		"alias": "staticMonochromeWhiteColor80"
-	},
-	"static_monochrome_white_88": {
-		"rgba": "rgba(255, 255, 255, 0.88)",
-		"hex": "#e0ffffff",
-		"figma": "static_monochrome-white/88",
-		"web": "--color-static-monochrome-white-88",
-		"alias": "staticMonochromeWhiteColor88"
-	},
-	"static_monochrome_white_100": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "static_monochrome-white/100",
-		"web": "--color-static-monochrome-white-100",
-		"alias": "staticMonochromeWhiteColor100"
-	},
-	"light_monochrome_black_2": {
-		"rgba": "rgba(0, 0, 0, 0.02)",
-		"hex": "#05000000",
-		"figma": "monochrome-black/2",
-		"web": "--color-light-monochrome-black-2",
-		"alias": "monochromeBlackColor2"
-	},
-	"light_monochrome_black_2_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.02)",
-		"hex": "#05ffffff",
-		"figma": "monochrome-black_inverted/2",
-		"web": "--color-light-monochrome-black-2-inverted",
-		"alias": "monochromeBlackColor2Inverted"
-	},
-	"light_monochrome_black_4": {
-		"rgba": "rgba(0, 0, 0, 0.04)",
-		"hex": "#0a000000",
-		"figma": "monochrome-black/4",
-		"web": "--color-light-monochrome-black-4",
-		"alias": "monochromeBlackColor4"
-	},
-	"light_monochrome_black_4_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.04)",
-		"hex": "#0affffff",
-		"figma": "monochrome-black_inverted/4",
-		"web": "--color-light-monochrome-black-4-inverted",
-		"alias": "monochromeBlackColor4Inverted"
-	},
-	"light_monochrome_black_6": {
-		"rgba": "rgba(0, 0, 0, 0.06)",
-		"hex": "#0f000000",
-		"figma": "monochrome-black/6",
-		"web": "--color-light-monochrome-black-6",
-		"alias": "monochromeBlackColor6"
-	},
-	"light_monochrome_black_6_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.06)",
-		"hex": "#0fffffff",
-		"figma": "monochrome-black_inverted/6",
-		"web": "--color-light-monochrome-black-6-inverted",
-		"alias": "monochromeBlackColor6Inverted"
-	},
-	"light_monochrome_black_8": {
-		"rgba": "rgba(0, 0, 0, 0.08)",
-		"hex": "#14000000",
-		"figma": "monochrome-black/8",
-		"web": "--color-light-monochrome-black-8",
-		"alias": "monochromeBlackColor8"
-	},
-	"light_monochrome_black_8_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.08)",
-		"hex": "#14ffffff",
-		"figma": "monochrome-black_inverted/8",
-		"web": "--color-light-monochrome-black-8-inverted",
-		"alias": "monochromeBlackColor8Inverted"
-	},
-	"light_monochrome_black_10": {
-		"rgba": "rgba(0, 0, 0, 0.1)",
-		"hex": "#1a000000",
-		"figma": "monochrome-black/10",
-		"web": "--color-light-monochrome-black-10",
-		"alias": "monochromeBlackColor10"
-	},
-	"light_monochrome_black_10_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.1)",
-		"hex": "#1affffff",
-		"figma": "monochrome-black_inverted/10",
-		"web": "--color-light-monochrome-black-10-inverted",
-		"alias": "monochromeBlackColor10Inverted"
-	},
-	"light_monochrome_black_12": {
-		"rgba": "rgba(0, 0, 0, 0.12)",
-		"hex": "#1f000000",
-		"figma": "monochrome-black/12",
-		"web": "--color-light-monochrome-black-12",
-		"alias": "monochromeBlackColor12"
-	},
-	"light_monochrome_black_12_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.12)",
-		"hex": "#1fffffff",
-		"figma": "monochrome-black_inverted/12",
-		"web": "--color-light-monochrome-black-12-inverted",
-		"alias": "monochromeBlackColor12Inverted"
-	},
-	"light_monochrome_black_16": {
-		"rgba": "rgba(0, 0, 0, 0.16)",
-		"hex": "#29000000",
-		"figma": "monochrome-black/16",
-		"web": "--color-light-monochrome-black-16",
-		"alias": "monochromeBlackColor16"
-	},
-	"light_monochrome_black_16_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.16)",
-		"hex": "#29ffffff",
-		"figma": "monochrome-black_inverted/16",
-		"web": "--color-light-monochrome-black-16-inverted",
-		"alias": "monochromeBlackColor16Inverted"
-	},
-	"light_monochrome_black_20": {
-		"rgba": "rgba(0, 0, 0, 0.2)",
-		"hex": "#33000000",
-		"figma": "monochrome-black/20",
-		"web": "--color-light-monochrome-black-20",
-		"alias": "monochromeBlackColor20"
-	},
-	"light_monochrome_black_20_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.2)",
-		"hex": "#33ffffff",
-		"figma": "monochrome-black_inverted/20",
-		"web": "--color-light-monochrome-black-20-inverted",
-		"alias": "monochromeBlackColor20Inverted"
-	},
-	"light_monochrome_black_24": {
-		"rgba": "rgba(0, 0, 0, 0.24)",
-		"hex": "#3d000000",
-		"figma": "monochrome-black/24",
-		"web": "--color-light-monochrome-black-24",
-		"alias": "monochromeBlackColor24"
-	},
-	"light_monochrome_black_24_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.24)",
-		"hex": "#3dffffff",
-		"figma": "monochrome-black_inverted/24",
-		"web": "--color-light-monochrome-black-24-inverted",
-		"alias": "monochromeBlackColor24Inverted"
-	},
-	"light_monochrome_black_32": {
-		"rgba": "rgba(0, 0, 0, 0.32)",
-		"hex": "#52000000",
-		"figma": "monochrome-black/32",
-		"web": "--color-light-monochrome-black-32",
-		"alias": "monochromeBlackColor32"
-	},
-	"light_monochrome_black_32_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.32)",
-		"hex": "#52ffffff",
-		"figma": "monochrome-black_inverted/32",
-		"web": "--color-light-monochrome-black-32-inverted",
-		"alias": "monochromeBlackColor32Inverted"
-	},
-	"light_monochrome_black_40": {
-		"rgba": "rgba(0, 0, 0, 0.4)",
-		"hex": "#66000000",
-		"figma": "monochrome-black/40",
-		"web": "--color-light-monochrome-black-40",
-		"alias": "monochromeBlackColor40"
-	},
-	"light_monochrome_black_40_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.4)",
-		"hex": "#66ffffff",
-		"figma": "monochrome-black_inverted/40",
-		"web": "--color-light-monochrome-black-40-inverted",
-		"alias": "monochromeBlackColor40Inverted"
-	},
-	"light_monochrome_black_44": {
-		"rgba": "rgba(0, 0, 0, 0.44)",
-		"hex": "#70000000",
-		"figma": "monochrome-black/44",
-		"web": "--color-light-monochrome-black-44",
-		"alias": "monochromeBlackColor44"
-	},
-	"light_monochrome_black_44_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.44)",
-		"hex": "#70ffffff",
-		"figma": "monochrome-black_inverted/44",
-		"web": "--color-light-monochrome-black-44-inverted",
-		"alias": "monochromeBlackColor44Inverted"
-	},
-	"light_monochrome_black_48": {
-		"rgba": "rgba(0, 0, 0, 0.48)",
-		"hex": "#7a000000",
-		"figma": "monochrome-black/48",
-		"web": "--color-light-monochrome-black-48",
-		"alias": "monochromeBlackColor48"
-	},
-	"light_monochrome_black_48_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.48)",
-		"hex": "#7affffff",
-		"figma": "monochrome-black_inverted/48",
-		"web": "--color-light-monochrome-black-48-inverted",
-		"alias": "monochromeBlackColor48Inverted"
-	},
-	"light_monochrome_black_56": {
-		"rgba": "rgba(0, 0, 0, 0.56)",
-		"hex": "#8f000000",
-		"figma": "monochrome-black/56",
-		"web": "--color-light-monochrome-black-56",
-		"alias": "monochromeBlackColor56"
-	},
-	"light_monochrome_black_56_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.56)",
-		"hex": "#8fffffff",
-		"figma": "monochrome-black_inverted/56",
-		"web": "--color-light-monochrome-black-56-inverted",
-		"alias": "monochromeBlackColor56Inverted"
-	},
-	"light_monochrome_black_64": {
-		"rgba": "rgba(0, 0, 0, 0.64)",
-		"hex": "#a3000000",
-		"figma": "monochrome-black/64",
-		"web": "--color-light-monochrome-black-64",
-		"alias": "monochromeBlackColor64"
-	},
-	"light_monochrome_black_64_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.64)",
-		"hex": "#a3ffffff",
-		"figma": "monochrome-black_inverted/64",
-		"web": "--color-light-monochrome-black-64-inverted",
-		"alias": "monochromeBlackColor64Inverted"
-	},
-	"light_monochrome_black_72": {
-		"rgba": "rgba(0, 0, 0, 0.72)",
-		"hex": "#b8000000",
-		"figma": "monochrome-black/72",
-		"web": "--color-light-monochrome-black-72",
-		"alias": "monochromeBlackColor72"
-	},
-	"light_monochrome_black_72_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.72)",
-		"hex": "#b8ffffff",
-		"figma": "monochrome-black_inverted/72",
-		"web": "--color-light-monochrome-black-72-inverted",
-		"alias": "monochromeBlackColor72Inverted"
-	},
-	"light_monochrome_black_80": {
-		"rgba": "rgba(0, 0, 0, 0.8)",
-		"hex": "#cc000000",
-		"figma": "monochrome-black/80",
-		"web": "--color-light-monochrome-black-80",
-		"alias": "monochromeBlackColor80"
-	},
-	"light_monochrome_black_80_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.8)",
-		"hex": "#ccffffff",
-		"figma": "monochrome-black_inverted/80",
-		"web": "--color-light-monochrome-black-80-inverted",
-		"alias": "monochromeBlackColor80Inverted"
-	},
-	"light_monochrome_black_88": {
-		"rgba": "rgba(0, 0, 0, 0.88)",
-		"hex": "#e0000000",
-		"figma": "monochrome-black/88",
-		"web": "--color-light-monochrome-black-88",
-		"alias": "monochromeBlackColor88"
-	},
-	"light_monochrome_black_88_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.88)",
-		"hex": "#e0ffffff",
-		"figma": "monochrome-black_inverted/88",
-		"web": "--color-light-monochrome-black-88-inverted",
-		"alias": "monochromeBlackColor88Inverted"
-	},
-	"light_monochrome_black_100": {
-		"rgba": "rgba(0, 0, 0, 1)",
-		"hex": "#000000",
-		"figma": "monochrome-black/100",
-		"web": "--color-light-monochrome-black-100",
-		"alias": "monochromeBlackColor100"
-	},
-	"light_monochrome_black_100_inverted": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "monochrome-black_inverted/100",
-		"web": "--color-light-monochrome-black-100-inverted",
-		"alias": "monochromeBlackColor100Inverted"
-	},
-	"light_monochrome_white_2": {
-		"rgba": "rgba(255, 255, 255, 0.02)",
-		"hex": "#05ffffff",
-		"figma": "monochrome-white/2",
-		"web": "--color-light-monochrome-white-2",
-		"alias": "monochromeWhiteColor2"
-	},
-	"light_monochrome_white_2_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.02)",
-		"hex": "#05000000",
-		"figma": "monochrome-white_inverted/2",
-		"web": "--color-light-monochrome-white-2-inverted",
-		"alias": "monochromeWhiteColor2Inverted"
-	},
-	"light_monochrome_white_4": {
-		"rgba": "rgba(255, 255, 255, 0.04)",
-		"hex": "#0affffff",
-		"figma": "monochrome-white/4",
-		"web": "--color-light-monochrome-white-4",
-		"alias": "monochromeWhiteColor4"
-	},
-	"light_monochrome_white_4_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.04)",
-		"hex": "#0a000000",
-		"figma": "monochrome-white_inverted/4",
-		"web": "--color-light-monochrome-white-4-inverted",
-		"alias": "monochromeWhiteColor4Inverted"
-	},
-	"light_monochrome_white_6": {
-		"rgba": "rgba(255, 255, 255, 0.06)",
-		"hex": "#0fffffff",
-		"figma": "monochrome-white/6",
-		"web": "--color-light-monochrome-white-6",
-		"alias": "monochromeWhiteColor6"
-	},
-	"light_monochrome_white_6_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.06)",
-		"hex": "#0f000000",
-		"figma": "monochrome-white_inverted/6",
-		"web": "--color-light-monochrome-white-6-inverted",
-		"alias": "monochromeWhiteColor6Inverted"
-	},
-	"light_monochrome_white_8": {
-		"rgba": "rgba(255, 255, 255, 0.08)",
-		"hex": "#14ffffff",
-		"figma": "monochrome-white/8",
-		"web": "--color-light-monochrome-white-8",
-		"alias": "monochromeWhiteColor8"
-	},
-	"light_monochrome_white_8_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.08)",
-		"hex": "#14000000",
-		"figma": "monochrome-white_inverted/8",
-		"web": "--color-light-monochrome-white-8-inverted",
-		"alias": "monochromeWhiteColor8Inverted"
-	},
-	"light_monochrome_white_10": {
-		"rgba": "rgba(255, 255, 255, 0.1)",
-		"hex": "#1affffff",
-		"figma": "monochrome-white/10",
-		"web": "--color-light-monochrome-white-10",
-		"alias": "monochromeWhiteColor10"
-	},
-	"light_monochrome_white_10_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.1)",
-		"hex": "#1a000000",
-		"figma": "monochrome-white_inverted/10",
-		"web": "--color-light-monochrome-white-10-inverted",
-		"alias": "monochromeWhiteColor10Inverted"
-	},
-	"light_monochrome_white_12": {
-		"rgba": "rgba(255, 255, 255, 0.12)",
-		"hex": "#1fffffff",
-		"figma": "monochrome-white/12",
-		"web": "--color-light-monochrome-white-12",
-		"alias": "monochromeWhiteColor12"
-	},
-	"light_monochrome_white_12_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.12)",
-		"hex": "#1f000000",
-		"figma": "monochrome-white_inverted/12",
-		"web": "--color-light-monochrome-white-12-inverted",
-		"alias": "monochromeWhiteColor12Inverted"
-	},
-	"light_monochrome_white_16": {
-		"rgba": "rgba(255, 255, 255, 0.16)",
-		"hex": "#29ffffff",
-		"figma": "monochrome-white/16",
-		"web": "--color-light-monochrome-white-16",
-		"alias": "monochromeWhiteColor16"
-	},
-	"light_monochrome_white_16_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.16)",
-		"hex": "#29000000",
-		"figma": "monochrome-white_inverted/16",
-		"web": "--color-light-monochrome-white-16-inverted",
-		"alias": "monochromeWhiteColor16Inverted"
-	},
-	"light_monochrome_white_20": {
-		"rgba": "rgba(255, 255, 255, 0.2)",
-		"hex": "#33ffffff",
-		"figma": "monochrome-white/20",
-		"web": "--color-light-monochrome-white-20",
-		"alias": "monochromeWhiteColor20"
-	},
-	"light_monochrome_white_20_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.2)",
-		"hex": "#33000000",
-		"figma": "monochrome-white_inverted/20",
-		"web": "--color-light-monochrome-white-20-inverted",
-		"alias": "monochromeWhiteColor20Inverted"
-	},
-	"light_monochrome_white_24": {
-		"rgba": "rgba(255, 255, 255, 0.24)",
-		"hex": "#3dffffff",
-		"figma": "monochrome-white/24",
-		"web": "--color-light-monochrome-white-24",
-		"alias": "monochromeWhiteColor24"
-	},
-	"light_monochrome_white_24_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.24)",
-		"hex": "#3d000000",
-		"figma": "monochrome-white_inverted/24",
-		"web": "--color-light-monochrome-white-24-inverted",
-		"alias": "monochromeWhiteColor24Inverted"
-	},
-	"light_monochrome_white_32": {
-		"rgba": "rgba(255, 255, 255, 0.32)",
-		"hex": "#52ffffff",
-		"figma": "monochrome-white/32",
-		"web": "--color-light-monochrome-white-32",
-		"alias": "monochromeWhiteColor32"
-	},
-	"light_monochrome_white_32_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.32)",
-		"hex": "#52000000",
-		"figma": "monochrome-white_inverted/32",
-		"web": "--color-light-monochrome-white-32-inverted",
-		"alias": "monochromeWhiteColor32Inverted"
-	},
-	"light_monochrome_white_40": {
-		"rgba": "rgba(255, 255, 255, 0.4)",
-		"hex": "#66ffffff",
-		"figma": "monochrome-white/40",
-		"web": "--color-light-monochrome-white-40",
-		"alias": "monochromeWhiteColor40"
-	},
-	"light_monochrome_white_40_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.4)",
-		"hex": "#66000000",
-		"figma": "monochrome-white_inverted/40",
-		"web": "--color-light-monochrome-white-40-inverted",
-		"alias": "monochromeWhiteColor40Inverted"
-	},
-	"light_monochrome_white_44": {
-		"rgba": "rgba(255, 255, 255, 0.44)",
-		"hex": "#70ffffff",
-		"figma": "monochrome-white/44",
-		"web": "--color-light-monochrome-white-44",
-		"alias": "monochromeWhiteColor44"
-	},
-	"light_monochrome_white_44_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.44)",
-		"hex": "#70000000",
-		"figma": "monochrome-white_inverted/44",
-		"web": "--color-light-monochrome-white-44-inverted",
-		"alias": "monochromeWhiteColor44Inverted"
-	},
-	"light_monochrome_white_48": {
-		"rgba": "rgba(255, 255, 255, 0.48)",
-		"hex": "#7affffff",
-		"figma": "monochrome-white/48",
-		"web": "--color-light-monochrome-white-48",
-		"alias": "monochromeWhiteColor48"
-	},
-	"light_monochrome_white_48_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.48)",
-		"hex": "#7a000000",
-		"figma": "monochrome-white_inverted/48",
-		"web": "--color-light-monochrome-white-48-inverted",
-		"alias": "monochromeWhiteColor48Inverted"
-	},
-	"light_monochrome_white_56": {
-		"rgba": "rgba(255, 255, 255, 0.56)",
-		"hex": "#8fffffff",
-		"figma": "monochrome-white/56",
-		"web": "--color-light-monochrome-white-56",
-		"alias": "monochromeWhiteColor56"
-	},
-	"light_monochrome_white_56_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.56)",
-		"hex": "#8f000000",
-		"figma": "monochrome-white_inverted/56",
-		"web": "--color-light-monochrome-white-56-inverted",
-		"alias": "monochromeWhiteColor56Inverted"
-	},
-	"light_monochrome_white_64": {
-		"rgba": "rgba(255, 255, 255, 0.64)",
-		"hex": "#a3ffffff",
-		"figma": "monochrome-white/64",
-		"web": "--color-light-monochrome-white-64",
-		"alias": "monochromeWhiteColor64"
-	},
-	"light_monochrome_white_64_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.64)",
-		"hex": "#a3000000",
-		"figma": "monochrome-white_inverted/64",
-		"web": "--color-light-monochrome-white-64-inverted",
-		"alias": "monochromeWhiteColor64Inverted"
-	},
-	"light_monochrome_white_72": {
-		"rgba": "rgba(255, 255, 255, 0.72)",
-		"hex": "#b8ffffff",
-		"figma": "monochrome-white/72",
-		"web": "--color-light-monochrome-white-72",
-		"alias": "monochromeWhiteColor72"
-	},
-	"light_monochrome_white_72_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.72)",
-		"hex": "#b8000000",
-		"figma": "monochrome-white_inverted/72",
-		"web": "--color-light-monochrome-white-72-inverted",
-		"alias": "monochromeWhiteColor72Inverted"
-	},
-	"light_monochrome_white_80": {
-		"rgba": "rgba(255, 255, 255, 0.8)",
-		"hex": "#ccffffff",
-		"figma": "monochrome-white/80",
-		"web": "--color-light-monochrome-white-80",
-		"alias": "monochromeWhiteColor80"
-	},
-	"light_monochrome_white_80_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.8)",
-		"hex": "#cc000000",
-		"figma": "monochrome-white_inverted/80",
-		"web": "--color-light-monochrome-white-80-inverted",
-		"alias": "monochromeWhiteColor80Inverted"
-	},
-	"light_monochrome_white_88": {
-		"rgba": "rgba(255, 255, 255, 0.88)",
-		"hex": "#e0ffffff",
-		"figma": "monochrome-white/88",
-		"web": "--color-light-monochrome-white-88",
-		"alias": "monochromeWhiteColor88"
-	},
-	"light_monochrome_white_88_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.88)",
-		"hex": "#e0000000",
-		"figma": "monochrome-white_inverted/88",
-		"web": "--color-light-monochrome-white-88-inverted",
-		"alias": "monochromeWhiteColor88Inverted"
-	},
-	"light_monochrome_white_100": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "monochrome-white/100",
-		"web": "--color-light-monochrome-white-100",
-		"alias": "monochromeWhiteColor100"
-	},
-	"light_monochrome_white_100_inverted": {
-		"rgba": "rgba(0, 0, 0, 1)",
-		"hex": "#000000",
-		"figma": "monochrome-white_inverted/100",
-		"web": "--color-light-monochrome-white-100-inverted",
-		"alias": "monochromeWhiteColor100Inverted"
-	},
-	"dark_monochrome_black_2": {
-		"rgba": "rgba(255, 255, 255, 0.02)",
-		"hex": "#05ffffff",
-		"figma": "monochrome-black/2",
-		"web": "--color-dark-monochrome-black-2",
-		"alias": "monochromeBlackColor2"
-	},
-	"dark_monochrome_black_2_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.02)",
-		"hex": "#05000000",
-		"figma": "monochrome-black_inverted/2",
-		"web": "--color-dark-monochrome-black-2-inverted",
-		"alias": "monochromeBlackColor2Inverted"
-	},
-	"dark_monochrome_black_4": {
-		"rgba": "rgba(255, 255, 255, 0.04)",
-		"hex": "#0affffff",
-		"figma": "monochrome-black/4",
-		"web": "--color-dark-monochrome-black-4",
-		"alias": "monochromeBlackColor4"
-	},
-	"dark_monochrome_black_4_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.04)",
-		"hex": "#0a000000",
-		"figma": "monochrome-black_inverted/4",
-		"web": "--color-dark-monochrome-black-4-inverted",
-		"alias": "monochromeBlackColor4Inverted"
-	},
-	"dark_monochrome_black_6": {
-		"rgba": "rgba(255, 255, 255, 0.06)",
-		"hex": "#0fffffff",
-		"figma": "monochrome-black/6",
-		"web": "--color-dark-monochrome-black-6",
-		"alias": "monochromeBlackColor6"
-	},
-	"dark_monochrome_black_6_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.06)",
-		"hex": "#0f000000",
-		"figma": "monochrome-black_inverted/6",
-		"web": "--color-dark-monochrome-black-6-inverted",
-		"alias": "monochromeBlackColor6Inverted"
-	},
-	"dark_monochrome_black_8": {
-		"rgba": "rgba(255, 255, 255, 0.08)",
-		"hex": "#14ffffff",
-		"figma": "monochrome-black/8",
-		"web": "--color-dark-monochrome-black-8",
-		"alias": "monochromeBlackColor8"
-	},
-	"dark_monochrome_black_8_inverted": {
-		"rgba": "rgba(0, 0, 0, 0.08)",
-		"hex": "#14000000",
-		"figma": "monochrome-black_inverted/8",
-		"web": "--color-dark-monochrome-black-8-inverted",
-		"alias": "monochromeBlackColor8Inverted"
-	},
 	"dark_monochrome_black_10": {
 		"rgba": "rgba(255, 255, 255, 0.1)",
 		"hex": "#1affffff",
@@ -866,6 +12,20 @@
 		"figma": "monochrome-black_inverted/10",
 		"web": "--color-dark-monochrome-black-10-inverted",
 		"alias": "monochromeBlackColor10Inverted"
+	},
+	"dark_monochrome_black_100": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "monochrome-black/100",
+		"web": "--color-dark-monochrome-black-100",
+		"alias": "monochromeBlackColor100"
+	},
+	"dark_monochrome_black_100_inverted": {
+		"rgba": "rgba(0, 0, 0, 1)",
+		"hex": "#000000",
+		"figma": "monochrome-black_inverted/100",
+		"web": "--color-dark-monochrome-black-100-inverted",
+		"alias": "monochromeBlackColor100Inverted"
 	},
 	"dark_monochrome_black_12": {
 		"rgba": "rgba(255, 255, 255, 0.12)",
@@ -894,6 +54,20 @@
 		"figma": "monochrome-black_inverted/16",
 		"web": "--color-dark-monochrome-black-16-inverted",
 		"alias": "monochromeBlackColor16Inverted"
+	},
+	"dark_monochrome_black_2": {
+		"rgba": "rgba(255, 255, 255, 0.02)",
+		"hex": "#05ffffff",
+		"figma": "monochrome-black/2",
+		"web": "--color-dark-monochrome-black-2",
+		"alias": "monochromeBlackColor2"
+	},
+	"dark_monochrome_black_2_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.02)",
+		"hex": "#05000000",
+		"figma": "monochrome-black_inverted/2",
+		"web": "--color-dark-monochrome-black-2-inverted",
+		"alias": "monochromeBlackColor2Inverted"
 	},
 	"dark_monochrome_black_20": {
 		"rgba": "rgba(255, 255, 255, 0.2)",
@@ -936,6 +110,20 @@
 		"figma": "monochrome-black_inverted/32",
 		"web": "--color-dark-monochrome-black-32-inverted",
 		"alias": "monochromeBlackColor32Inverted"
+	},
+	"dark_monochrome_black_4": {
+		"rgba": "rgba(255, 255, 255, 0.04)",
+		"hex": "#0affffff",
+		"figma": "monochrome-black/4",
+		"web": "--color-dark-monochrome-black-4",
+		"alias": "monochromeBlackColor4"
+	},
+	"dark_monochrome_black_4_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.04)",
+		"hex": "#0a000000",
+		"figma": "monochrome-black_inverted/4",
+		"web": "--color-dark-monochrome-black-4-inverted",
+		"alias": "monochromeBlackColor4Inverted"
 	},
 	"dark_monochrome_black_40": {
 		"rgba": "rgba(255, 255, 255, 0.4)",
@@ -993,6 +181,20 @@
 		"web": "--color-dark-monochrome-black-56-inverted",
 		"alias": "monochromeBlackColor56Inverted"
 	},
+	"dark_monochrome_black_6": {
+		"rgba": "rgba(255, 255, 255, 0.06)",
+		"hex": "#0fffffff",
+		"figma": "monochrome-black/6",
+		"web": "--color-dark-monochrome-black-6",
+		"alias": "monochromeBlackColor6"
+	},
+	"dark_monochrome_black_6_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.06)",
+		"hex": "#0f000000",
+		"figma": "monochrome-black_inverted/6",
+		"web": "--color-dark-monochrome-black-6-inverted",
+		"alias": "monochromeBlackColor6Inverted"
+	},
 	"dark_monochrome_black_64": {
 		"rgba": "rgba(255, 255, 255, 0.64)",
 		"hex": "#a3ffffff",
@@ -1020,6 +222,20 @@
 		"figma": "monochrome-black_inverted/72",
 		"web": "--color-dark-monochrome-black-72-inverted",
 		"alias": "monochromeBlackColor72Inverted"
+	},
+	"dark_monochrome_black_8": {
+		"rgba": "rgba(255, 255, 255, 0.08)",
+		"hex": "#14ffffff",
+		"figma": "monochrome-black/8",
+		"web": "--color-dark-monochrome-black-8",
+		"alias": "monochromeBlackColor8"
+	},
+	"dark_monochrome_black_8_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.08)",
+		"hex": "#14000000",
+		"figma": "monochrome-black_inverted/8",
+		"web": "--color-dark-monochrome-black-8-inverted",
+		"alias": "monochromeBlackColor8Inverted"
 	},
 	"dark_monochrome_black_80": {
 		"rgba": "rgba(255, 255, 255, 0.8)",
@@ -1049,76 +265,6 @@
 		"web": "--color-dark-monochrome-black-88-inverted",
 		"alias": "monochromeBlackColor88Inverted"
 	},
-	"dark_monochrome_black_100": {
-		"rgba": "rgba(255, 255, 255, 1)",
-		"hex": "#ffffff",
-		"figma": "monochrome-black/100",
-		"web": "--color-dark-monochrome-black-100",
-		"alias": "monochromeBlackColor100"
-	},
-	"dark_monochrome_black_100_inverted": {
-		"rgba": "rgba(0, 0, 0, 1)",
-		"hex": "#000000",
-		"figma": "monochrome-black_inverted/100",
-		"web": "--color-dark-monochrome-black-100-inverted",
-		"alias": "monochromeBlackColor100Inverted"
-	},
-	"dark_monochrome_white_2": {
-		"rgba": "rgba(0, 0, 0, 0.02)",
-		"hex": "#05000000",
-		"figma": "monochrome-white/2",
-		"web": "--color-dark-monochrome-white-2",
-		"alias": "monochromeWhiteColor2"
-	},
-	"dark_monochrome_white_2_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.02)",
-		"hex": "#05ffffff",
-		"figma": "monochrome-white_inverted/2",
-		"web": "--color-dark-monochrome-white-2-inverted",
-		"alias": "monochromeWhiteColor2Inverted"
-	},
-	"dark_monochrome_white_4": {
-		"rgba": "rgba(0, 0, 0, 0.04)",
-		"hex": "#0a000000",
-		"figma": "monochrome-white/4",
-		"web": "--color-dark-monochrome-white-4",
-		"alias": "monochromeWhiteColor4"
-	},
-	"dark_monochrome_white_4_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.04)",
-		"hex": "#0affffff",
-		"figma": "monochrome-white_inverted/4",
-		"web": "--color-dark-monochrome-white-4-inverted",
-		"alias": "monochromeWhiteColor4Inverted"
-	},
-	"dark_monochrome_white_6": {
-		"rgba": "rgba(0, 0, 0, 0.06)",
-		"hex": "#0f000000",
-		"figma": "monochrome-white/6",
-		"web": "--color-dark-monochrome-white-6",
-		"alias": "monochromeWhiteColor6"
-	},
-	"dark_monochrome_white_6_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.06)",
-		"hex": "#0fffffff",
-		"figma": "monochrome-white_inverted/6",
-		"web": "--color-dark-monochrome-white-6-inverted",
-		"alias": "monochromeWhiteColor6Inverted"
-	},
-	"dark_monochrome_white_8": {
-		"rgba": "rgba(0, 0, 0, 0.08)",
-		"hex": "#14000000",
-		"figma": "monochrome-white/8",
-		"web": "--color-dark-monochrome-white-8",
-		"alias": "monochromeWhiteColor8"
-	},
-	"dark_monochrome_white_8_inverted": {
-		"rgba": "rgba(255, 255, 255, 0.08)",
-		"hex": "#14ffffff",
-		"figma": "monochrome-white_inverted/8",
-		"web": "--color-dark-monochrome-white-8-inverted",
-		"alias": "monochromeWhiteColor8Inverted"
-	},
 	"dark_monochrome_white_10": {
 		"rgba": "rgba(0, 0, 0, 0.1)",
 		"hex": "#1a000000",
@@ -1132,6 +278,20 @@
 		"figma": "monochrome-white_inverted/10",
 		"web": "--color-dark-monochrome-white-10-inverted",
 		"alias": "monochromeWhiteColor10Inverted"
+	},
+	"dark_monochrome_white_100": {
+		"rgba": "rgba(0, 0, 0, 1)",
+		"hex": "#000000",
+		"figma": "monochrome-white/100",
+		"web": "--color-dark-monochrome-white-100",
+		"alias": "monochromeWhiteColor100"
+	},
+	"dark_monochrome_white_100_inverted": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "monochrome-white_inverted/100",
+		"web": "--color-dark-monochrome-white-100-inverted",
+		"alias": "monochromeWhiteColor100Inverted"
 	},
 	"dark_monochrome_white_12": {
 		"rgba": "rgba(0, 0, 0, 0.12)",
@@ -1160,6 +320,20 @@
 		"figma": "monochrome-white_inverted/16",
 		"web": "--color-dark-monochrome-white-16-inverted",
 		"alias": "monochromeWhiteColor16Inverted"
+	},
+	"dark_monochrome_white_2": {
+		"rgba": "rgba(0, 0, 0, 0.02)",
+		"hex": "#05000000",
+		"figma": "monochrome-white/2",
+		"web": "--color-dark-monochrome-white-2",
+		"alias": "monochromeWhiteColor2"
+	},
+	"dark_monochrome_white_2_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.02)",
+		"hex": "#05ffffff",
+		"figma": "monochrome-white_inverted/2",
+		"web": "--color-dark-monochrome-white-2-inverted",
+		"alias": "monochromeWhiteColor2Inverted"
 	},
 	"dark_monochrome_white_20": {
 		"rgba": "rgba(0, 0, 0, 0.2)",
@@ -1202,6 +376,20 @@
 		"figma": "monochrome-white_inverted/32",
 		"web": "--color-dark-monochrome-white-32-inverted",
 		"alias": "monochromeWhiteColor32Inverted"
+	},
+	"dark_monochrome_white_4": {
+		"rgba": "rgba(0, 0, 0, 0.04)",
+		"hex": "#0a000000",
+		"figma": "monochrome-white/4",
+		"web": "--color-dark-monochrome-white-4",
+		"alias": "monochromeWhiteColor4"
+	},
+	"dark_monochrome_white_4_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.04)",
+		"hex": "#0affffff",
+		"figma": "monochrome-white_inverted/4",
+		"web": "--color-dark-monochrome-white-4-inverted",
+		"alias": "monochromeWhiteColor4Inverted"
 	},
 	"dark_monochrome_white_40": {
 		"rgba": "rgba(0, 0, 0, 0.4)",
@@ -1259,6 +447,20 @@
 		"web": "--color-dark-monochrome-white-56-inverted",
 		"alias": "monochromeWhiteColor56Inverted"
 	},
+	"dark_monochrome_white_6": {
+		"rgba": "rgba(0, 0, 0, 0.06)",
+		"hex": "#0f000000",
+		"figma": "monochrome-white/6",
+		"web": "--color-dark-monochrome-white-6",
+		"alias": "monochromeWhiteColor6"
+	},
+	"dark_monochrome_white_6_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.06)",
+		"hex": "#0fffffff",
+		"figma": "monochrome-white_inverted/6",
+		"web": "--color-dark-monochrome-white-6-inverted",
+		"alias": "monochromeWhiteColor6Inverted"
+	},
 	"dark_monochrome_white_64": {
 		"rgba": "rgba(0, 0, 0, 0.64)",
 		"hex": "#a3000000",
@@ -1286,6 +488,20 @@
 		"figma": "monochrome-white_inverted/72",
 		"web": "--color-dark-monochrome-white-72-inverted",
 		"alias": "monochromeWhiteColor72Inverted"
+	},
+	"dark_monochrome_white_8": {
+		"rgba": "rgba(0, 0, 0, 0.08)",
+		"hex": "#14000000",
+		"figma": "monochrome-white/8",
+		"web": "--color-dark-monochrome-white-8",
+		"alias": "monochromeWhiteColor8"
+	},
+	"dark_monochrome_white_8_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.08)",
+		"hex": "#14ffffff",
+		"figma": "monochrome-white_inverted/8",
+		"web": "--color-dark-monochrome-white-8-inverted",
+		"alias": "monochromeWhiteColor8Inverted"
 	},
 	"dark_monochrome_white_80": {
 		"rgba": "rgba(0, 0, 0, 0.8)",
@@ -1315,18 +531,802 @@
 		"web": "--color-dark-monochrome-white-88-inverted",
 		"alias": "monochromeWhiteColor88Inverted"
 	},
-	"dark_monochrome_white_100": {
+	"light_monochrome_black_10": {
+		"rgba": "rgba(0, 0, 0, 0.1)",
+		"hex": "#1a000000",
+		"figma": "monochrome-black/10",
+		"web": "--color-light-monochrome-black-10",
+		"alias": "monochromeBlackColor10"
+	},
+	"light_monochrome_black_10_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.1)",
+		"hex": "#1affffff",
+		"figma": "monochrome-black_inverted/10",
+		"web": "--color-light-monochrome-black-10-inverted",
+		"alias": "monochromeBlackColor10Inverted"
+	},
+	"light_monochrome_black_100": {
 		"rgba": "rgba(0, 0, 0, 1)",
 		"hex": "#000000",
-		"figma": "monochrome-white/100",
-		"web": "--color-dark-monochrome-white-100",
-		"alias": "monochromeWhiteColor100"
+		"figma": "monochrome-black/100",
+		"web": "--color-light-monochrome-black-100",
+		"alias": "monochromeBlackColor100"
 	},
-	"dark_monochrome_white_100_inverted": {
+	"light_monochrome_black_100_inverted": {
 		"rgba": "rgba(255, 255, 255, 1)",
 		"hex": "#ffffff",
+		"figma": "monochrome-black_inverted/100",
+		"web": "--color-light-monochrome-black-100-inverted",
+		"alias": "monochromeBlackColor100Inverted"
+	},
+	"light_monochrome_black_12": {
+		"rgba": "rgba(0, 0, 0, 0.12)",
+		"hex": "#1f000000",
+		"figma": "monochrome-black/12",
+		"web": "--color-light-monochrome-black-12",
+		"alias": "monochromeBlackColor12"
+	},
+	"light_monochrome_black_12_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.12)",
+		"hex": "#1fffffff",
+		"figma": "monochrome-black_inverted/12",
+		"web": "--color-light-monochrome-black-12-inverted",
+		"alias": "monochromeBlackColor12Inverted"
+	},
+	"light_monochrome_black_16": {
+		"rgba": "rgba(0, 0, 0, 0.16)",
+		"hex": "#29000000",
+		"figma": "monochrome-black/16",
+		"web": "--color-light-monochrome-black-16",
+		"alias": "monochromeBlackColor16"
+	},
+	"light_monochrome_black_16_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.16)",
+		"hex": "#29ffffff",
+		"figma": "monochrome-black_inverted/16",
+		"web": "--color-light-monochrome-black-16-inverted",
+		"alias": "monochromeBlackColor16Inverted"
+	},
+	"light_monochrome_black_2": {
+		"rgba": "rgba(0, 0, 0, 0.02)",
+		"hex": "#05000000",
+		"figma": "monochrome-black/2",
+		"web": "--color-light-monochrome-black-2",
+		"alias": "monochromeBlackColor2"
+	},
+	"light_monochrome_black_2_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.02)",
+		"hex": "#05ffffff",
+		"figma": "monochrome-black_inverted/2",
+		"web": "--color-light-monochrome-black-2-inverted",
+		"alias": "monochromeBlackColor2Inverted"
+	},
+	"light_monochrome_black_20": {
+		"rgba": "rgba(0, 0, 0, 0.2)",
+		"hex": "#33000000",
+		"figma": "monochrome-black/20",
+		"web": "--color-light-monochrome-black-20",
+		"alias": "monochromeBlackColor20"
+	},
+	"light_monochrome_black_20_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.2)",
+		"hex": "#33ffffff",
+		"figma": "monochrome-black_inverted/20",
+		"web": "--color-light-monochrome-black-20-inverted",
+		"alias": "monochromeBlackColor20Inverted"
+	},
+	"light_monochrome_black_24": {
+		"rgba": "rgba(0, 0, 0, 0.24)",
+		"hex": "#3d000000",
+		"figma": "monochrome-black/24",
+		"web": "--color-light-monochrome-black-24",
+		"alias": "monochromeBlackColor24"
+	},
+	"light_monochrome_black_24_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.24)",
+		"hex": "#3dffffff",
+		"figma": "monochrome-black_inverted/24",
+		"web": "--color-light-monochrome-black-24-inverted",
+		"alias": "monochromeBlackColor24Inverted"
+	},
+	"light_monochrome_black_32": {
+		"rgba": "rgba(0, 0, 0, 0.32)",
+		"hex": "#52000000",
+		"figma": "monochrome-black/32",
+		"web": "--color-light-monochrome-black-32",
+		"alias": "monochromeBlackColor32"
+	},
+	"light_monochrome_black_32_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.32)",
+		"hex": "#52ffffff",
+		"figma": "monochrome-black_inverted/32",
+		"web": "--color-light-monochrome-black-32-inverted",
+		"alias": "monochromeBlackColor32Inverted"
+	},
+	"light_monochrome_black_4": {
+		"rgba": "rgba(0, 0, 0, 0.04)",
+		"hex": "#0a000000",
+		"figma": "monochrome-black/4",
+		"web": "--color-light-monochrome-black-4",
+		"alias": "monochromeBlackColor4"
+	},
+	"light_monochrome_black_4_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.04)",
+		"hex": "#0affffff",
+		"figma": "monochrome-black_inverted/4",
+		"web": "--color-light-monochrome-black-4-inverted",
+		"alias": "monochromeBlackColor4Inverted"
+	},
+	"light_monochrome_black_40": {
+		"rgba": "rgba(0, 0, 0, 0.4)",
+		"hex": "#66000000",
+		"figma": "monochrome-black/40",
+		"web": "--color-light-monochrome-black-40",
+		"alias": "monochromeBlackColor40"
+	},
+	"light_monochrome_black_40_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.4)",
+		"hex": "#66ffffff",
+		"figma": "monochrome-black_inverted/40",
+		"web": "--color-light-monochrome-black-40-inverted",
+		"alias": "monochromeBlackColor40Inverted"
+	},
+	"light_monochrome_black_44": {
+		"rgba": "rgba(0, 0, 0, 0.44)",
+		"hex": "#70000000",
+		"figma": "monochrome-black/44",
+		"web": "--color-light-monochrome-black-44",
+		"alias": "monochromeBlackColor44"
+	},
+	"light_monochrome_black_44_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.44)",
+		"hex": "#70ffffff",
+		"figma": "monochrome-black_inverted/44",
+		"web": "--color-light-monochrome-black-44-inverted",
+		"alias": "monochromeBlackColor44Inverted"
+	},
+	"light_monochrome_black_48": {
+		"rgba": "rgba(0, 0, 0, 0.48)",
+		"hex": "#7a000000",
+		"figma": "monochrome-black/48",
+		"web": "--color-light-monochrome-black-48",
+		"alias": "monochromeBlackColor48"
+	},
+	"light_monochrome_black_48_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.48)",
+		"hex": "#7affffff",
+		"figma": "monochrome-black_inverted/48",
+		"web": "--color-light-monochrome-black-48-inverted",
+		"alias": "monochromeBlackColor48Inverted"
+	},
+	"light_monochrome_black_56": {
+		"rgba": "rgba(0, 0, 0, 0.56)",
+		"hex": "#8f000000",
+		"figma": "monochrome-black/56",
+		"web": "--color-light-monochrome-black-56",
+		"alias": "monochromeBlackColor56"
+	},
+	"light_monochrome_black_56_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.56)",
+		"hex": "#8fffffff",
+		"figma": "monochrome-black_inverted/56",
+		"web": "--color-light-monochrome-black-56-inverted",
+		"alias": "monochromeBlackColor56Inverted"
+	},
+	"light_monochrome_black_6": {
+		"rgba": "rgba(0, 0, 0, 0.06)",
+		"hex": "#0f000000",
+		"figma": "monochrome-black/6",
+		"web": "--color-light-monochrome-black-6",
+		"alias": "monochromeBlackColor6"
+	},
+	"light_monochrome_black_6_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.06)",
+		"hex": "#0fffffff",
+		"figma": "monochrome-black_inverted/6",
+		"web": "--color-light-monochrome-black-6-inverted",
+		"alias": "monochromeBlackColor6Inverted"
+	},
+	"light_monochrome_black_64": {
+		"rgba": "rgba(0, 0, 0, 0.64)",
+		"hex": "#a3000000",
+		"figma": "monochrome-black/64",
+		"web": "--color-light-monochrome-black-64",
+		"alias": "monochromeBlackColor64"
+	},
+	"light_monochrome_black_64_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.64)",
+		"hex": "#a3ffffff",
+		"figma": "monochrome-black_inverted/64",
+		"web": "--color-light-monochrome-black-64-inverted",
+		"alias": "monochromeBlackColor64Inverted"
+	},
+	"light_monochrome_black_72": {
+		"rgba": "rgba(0, 0, 0, 0.72)",
+		"hex": "#b8000000",
+		"figma": "monochrome-black/72",
+		"web": "--color-light-monochrome-black-72",
+		"alias": "monochromeBlackColor72"
+	},
+	"light_monochrome_black_72_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.72)",
+		"hex": "#b8ffffff",
+		"figma": "monochrome-black_inverted/72",
+		"web": "--color-light-monochrome-black-72-inverted",
+		"alias": "monochromeBlackColor72Inverted"
+	},
+	"light_monochrome_black_8": {
+		"rgba": "rgba(0, 0, 0, 0.08)",
+		"hex": "#14000000",
+		"figma": "monochrome-black/8",
+		"web": "--color-light-monochrome-black-8",
+		"alias": "monochromeBlackColor8"
+	},
+	"light_monochrome_black_8_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.08)",
+		"hex": "#14ffffff",
+		"figma": "monochrome-black_inverted/8",
+		"web": "--color-light-monochrome-black-8-inverted",
+		"alias": "monochromeBlackColor8Inverted"
+	},
+	"light_monochrome_black_80": {
+		"rgba": "rgba(0, 0, 0, 0.8)",
+		"hex": "#cc000000",
+		"figma": "monochrome-black/80",
+		"web": "--color-light-monochrome-black-80",
+		"alias": "monochromeBlackColor80"
+	},
+	"light_monochrome_black_80_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.8)",
+		"hex": "#ccffffff",
+		"figma": "monochrome-black_inverted/80",
+		"web": "--color-light-monochrome-black-80-inverted",
+		"alias": "monochromeBlackColor80Inverted"
+	},
+	"light_monochrome_black_88": {
+		"rgba": "rgba(0, 0, 0, 0.88)",
+		"hex": "#e0000000",
+		"figma": "monochrome-black/88",
+		"web": "--color-light-monochrome-black-88",
+		"alias": "monochromeBlackColor88"
+	},
+	"light_monochrome_black_88_inverted": {
+		"rgba": "rgba(255, 255, 255, 0.88)",
+		"hex": "#e0ffffff",
+		"figma": "monochrome-black_inverted/88",
+		"web": "--color-light-monochrome-black-88-inverted",
+		"alias": "monochromeBlackColor88Inverted"
+	},
+	"light_monochrome_white_10": {
+		"rgba": "rgba(255, 255, 255, 0.1)",
+		"hex": "#1affffff",
+		"figma": "monochrome-white/10",
+		"web": "--color-light-monochrome-white-10",
+		"alias": "monochromeWhiteColor10"
+	},
+	"light_monochrome_white_10_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.1)",
+		"hex": "#1a000000",
+		"figma": "monochrome-white_inverted/10",
+		"web": "--color-light-monochrome-white-10-inverted",
+		"alias": "monochromeWhiteColor10Inverted"
+	},
+	"light_monochrome_white_100": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "monochrome-white/100",
+		"web": "--color-light-monochrome-white-100",
+		"alias": "monochromeWhiteColor100"
+	},
+	"light_monochrome_white_100_inverted": {
+		"rgba": "rgba(0, 0, 0, 1)",
+		"hex": "#000000",
 		"figma": "monochrome-white_inverted/100",
-		"web": "--color-dark-monochrome-white-100-inverted",
+		"web": "--color-light-monochrome-white-100-inverted",
 		"alias": "monochromeWhiteColor100Inverted"
+	},
+	"light_monochrome_white_12": {
+		"rgba": "rgba(255, 255, 255, 0.12)",
+		"hex": "#1fffffff",
+		"figma": "monochrome-white/12",
+		"web": "--color-light-monochrome-white-12",
+		"alias": "monochromeWhiteColor12"
+	},
+	"light_monochrome_white_12_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.12)",
+		"hex": "#1f000000",
+		"figma": "monochrome-white_inverted/12",
+		"web": "--color-light-monochrome-white-12-inverted",
+		"alias": "monochromeWhiteColor12Inverted"
+	},
+	"light_monochrome_white_16": {
+		"rgba": "rgba(255, 255, 255, 0.16)",
+		"hex": "#29ffffff",
+		"figma": "monochrome-white/16",
+		"web": "--color-light-monochrome-white-16",
+		"alias": "monochromeWhiteColor16"
+	},
+	"light_monochrome_white_16_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.16)",
+		"hex": "#29000000",
+		"figma": "monochrome-white_inverted/16",
+		"web": "--color-light-monochrome-white-16-inverted",
+		"alias": "monochromeWhiteColor16Inverted"
+	},
+	"light_monochrome_white_2": {
+		"rgba": "rgba(255, 255, 255, 0.02)",
+		"hex": "#05ffffff",
+		"figma": "monochrome-white/2",
+		"web": "--color-light-monochrome-white-2",
+		"alias": "monochromeWhiteColor2"
+	},
+	"light_monochrome_white_2_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.02)",
+		"hex": "#05000000",
+		"figma": "monochrome-white_inverted/2",
+		"web": "--color-light-monochrome-white-2-inverted",
+		"alias": "monochromeWhiteColor2Inverted"
+	},
+	"light_monochrome_white_20": {
+		"rgba": "rgba(255, 255, 255, 0.2)",
+		"hex": "#33ffffff",
+		"figma": "monochrome-white/20",
+		"web": "--color-light-monochrome-white-20",
+		"alias": "monochromeWhiteColor20"
+	},
+	"light_monochrome_white_20_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.2)",
+		"hex": "#33000000",
+		"figma": "monochrome-white_inverted/20",
+		"web": "--color-light-monochrome-white-20-inverted",
+		"alias": "monochromeWhiteColor20Inverted"
+	},
+	"light_monochrome_white_24": {
+		"rgba": "rgba(255, 255, 255, 0.24)",
+		"hex": "#3dffffff",
+		"figma": "monochrome-white/24",
+		"web": "--color-light-monochrome-white-24",
+		"alias": "monochromeWhiteColor24"
+	},
+	"light_monochrome_white_24_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.24)",
+		"hex": "#3d000000",
+		"figma": "monochrome-white_inverted/24",
+		"web": "--color-light-monochrome-white-24-inverted",
+		"alias": "monochromeWhiteColor24Inverted"
+	},
+	"light_monochrome_white_32": {
+		"rgba": "rgba(255, 255, 255, 0.32)",
+		"hex": "#52ffffff",
+		"figma": "monochrome-white/32",
+		"web": "--color-light-monochrome-white-32",
+		"alias": "monochromeWhiteColor32"
+	},
+	"light_monochrome_white_32_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.32)",
+		"hex": "#52000000",
+		"figma": "monochrome-white_inverted/32",
+		"web": "--color-light-monochrome-white-32-inverted",
+		"alias": "monochromeWhiteColor32Inverted"
+	},
+	"light_monochrome_white_4": {
+		"rgba": "rgba(255, 255, 255, 0.04)",
+		"hex": "#0affffff",
+		"figma": "monochrome-white/4",
+		"web": "--color-light-monochrome-white-4",
+		"alias": "monochromeWhiteColor4"
+	},
+	"light_monochrome_white_4_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.04)",
+		"hex": "#0a000000",
+		"figma": "monochrome-white_inverted/4",
+		"web": "--color-light-monochrome-white-4-inverted",
+		"alias": "monochromeWhiteColor4Inverted"
+	},
+	"light_monochrome_white_40": {
+		"rgba": "rgba(255, 255, 255, 0.4)",
+		"hex": "#66ffffff",
+		"figma": "monochrome-white/40",
+		"web": "--color-light-monochrome-white-40",
+		"alias": "monochromeWhiteColor40"
+	},
+	"light_monochrome_white_40_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.4)",
+		"hex": "#66000000",
+		"figma": "monochrome-white_inverted/40",
+		"web": "--color-light-monochrome-white-40-inverted",
+		"alias": "monochromeWhiteColor40Inverted"
+	},
+	"light_monochrome_white_44": {
+		"rgba": "rgba(255, 255, 255, 0.44)",
+		"hex": "#70ffffff",
+		"figma": "monochrome-white/44",
+		"web": "--color-light-monochrome-white-44",
+		"alias": "monochromeWhiteColor44"
+	},
+	"light_monochrome_white_44_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.44)",
+		"hex": "#70000000",
+		"figma": "monochrome-white_inverted/44",
+		"web": "--color-light-monochrome-white-44-inverted",
+		"alias": "monochromeWhiteColor44Inverted"
+	},
+	"light_monochrome_white_48": {
+		"rgba": "rgba(255, 255, 255, 0.48)",
+		"hex": "#7affffff",
+		"figma": "monochrome-white/48",
+		"web": "--color-light-monochrome-white-48",
+		"alias": "monochromeWhiteColor48"
+	},
+	"light_monochrome_white_48_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.48)",
+		"hex": "#7a000000",
+		"figma": "monochrome-white_inverted/48",
+		"web": "--color-light-monochrome-white-48-inverted",
+		"alias": "monochromeWhiteColor48Inverted"
+	},
+	"light_monochrome_white_56": {
+		"rgba": "rgba(255, 255, 255, 0.56)",
+		"hex": "#8fffffff",
+		"figma": "monochrome-white/56",
+		"web": "--color-light-monochrome-white-56",
+		"alias": "monochromeWhiteColor56"
+	},
+	"light_monochrome_white_56_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.56)",
+		"hex": "#8f000000",
+		"figma": "monochrome-white_inverted/56",
+		"web": "--color-light-monochrome-white-56-inverted",
+		"alias": "monochromeWhiteColor56Inverted"
+	},
+	"light_monochrome_white_6": {
+		"rgba": "rgba(255, 255, 255, 0.06)",
+		"hex": "#0fffffff",
+		"figma": "monochrome-white/6",
+		"web": "--color-light-monochrome-white-6",
+		"alias": "monochromeWhiteColor6"
+	},
+	"light_monochrome_white_6_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.06)",
+		"hex": "#0f000000",
+		"figma": "monochrome-white_inverted/6",
+		"web": "--color-light-monochrome-white-6-inverted",
+		"alias": "monochromeWhiteColor6Inverted"
+	},
+	"light_monochrome_white_64": {
+		"rgba": "rgba(255, 255, 255, 0.64)",
+		"hex": "#a3ffffff",
+		"figma": "monochrome-white/64",
+		"web": "--color-light-monochrome-white-64",
+		"alias": "monochromeWhiteColor64"
+	},
+	"light_monochrome_white_64_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.64)",
+		"hex": "#a3000000",
+		"figma": "monochrome-white_inverted/64",
+		"web": "--color-light-monochrome-white-64-inverted",
+		"alias": "monochromeWhiteColor64Inverted"
+	},
+	"light_monochrome_white_72": {
+		"rgba": "rgba(255, 255, 255, 0.72)",
+		"hex": "#b8ffffff",
+		"figma": "monochrome-white/72",
+		"web": "--color-light-monochrome-white-72",
+		"alias": "monochromeWhiteColor72"
+	},
+	"light_monochrome_white_72_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.72)",
+		"hex": "#b8000000",
+		"figma": "monochrome-white_inverted/72",
+		"web": "--color-light-monochrome-white-72-inverted",
+		"alias": "monochromeWhiteColor72Inverted"
+	},
+	"light_monochrome_white_8": {
+		"rgba": "rgba(255, 255, 255, 0.08)",
+		"hex": "#14ffffff",
+		"figma": "monochrome-white/8",
+		"web": "--color-light-monochrome-white-8",
+		"alias": "monochromeWhiteColor8"
+	},
+	"light_monochrome_white_8_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.08)",
+		"hex": "#14000000",
+		"figma": "monochrome-white_inverted/8",
+		"web": "--color-light-monochrome-white-8-inverted",
+		"alias": "monochromeWhiteColor8Inverted"
+	},
+	"light_monochrome_white_80": {
+		"rgba": "rgba(255, 255, 255, 0.8)",
+		"hex": "#ccffffff",
+		"figma": "monochrome-white/80",
+		"web": "--color-light-monochrome-white-80",
+		"alias": "monochromeWhiteColor80"
+	},
+	"light_monochrome_white_80_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.8)",
+		"hex": "#cc000000",
+		"figma": "monochrome-white_inverted/80",
+		"web": "--color-light-monochrome-white-80-inverted",
+		"alias": "monochromeWhiteColor80Inverted"
+	},
+	"light_monochrome_white_88": {
+		"rgba": "rgba(255, 255, 255, 0.88)",
+		"hex": "#e0ffffff",
+		"figma": "monochrome-white/88",
+		"web": "--color-light-monochrome-white-88",
+		"alias": "monochromeWhiteColor88"
+	},
+	"light_monochrome_white_88_inverted": {
+		"rgba": "rgba(0, 0, 0, 0.88)",
+		"hex": "#e0000000",
+		"figma": "monochrome-white_inverted/88",
+		"web": "--color-light-monochrome-white-88-inverted",
+		"alias": "monochromeWhiteColor88Inverted"
+	},
+	"static_monochrome_black_10": {
+		"rgba": "rgba(0, 0, 0, 0.1)",
+		"hex": "#1a000000",
+		"figma": "static_monochrome-black/10",
+		"web": "--color-static-monochrome-black-10",
+		"alias": "staticMonochromeBlackColor10"
+	},
+	"static_monochrome_black_100": {
+		"rgba": "rgba(0, 0, 0, 1)",
+		"hex": "#000000",
+		"figma": "static_monochrome-black/100",
+		"web": "--color-static-monochrome-black-100",
+		"alias": "staticMonochromeBlackColor100"
+	},
+	"static_monochrome_black_12": {
+		"rgba": "rgba(0, 0, 0, 0.12)",
+		"hex": "#1f000000",
+		"figma": "static_monochrome-black/12",
+		"web": "--color-static-monochrome-black-12",
+		"alias": "staticMonochromeBlackColor12"
+	},
+	"static_monochrome_black_16": {
+		"rgba": "rgba(0, 0, 0, 0.16)",
+		"hex": "#29000000",
+		"figma": "static_monochrome-black/16",
+		"web": "--color-static-monochrome-black-16",
+		"alias": "staticMonochromeBlackColor16"
+	},
+	"static_monochrome_black_2": {
+		"rgba": "rgba(0, 0, 0, 0.02)",
+		"hex": "#05000000",
+		"figma": "static_monochrome-black/2",
+		"web": "--color-static-monochrome-black-2",
+		"alias": "staticMonochromeBlackColor2"
+	},
+	"static_monochrome_black_20": {
+		"rgba": "rgba(0, 0, 0, 0.2)",
+		"hex": "#33000000",
+		"figma": "static_monochrome-black/20",
+		"web": "--color-static-monochrome-black-20",
+		"alias": "staticMonochromeBlackColor20"
+	},
+	"static_monochrome_black_24": {
+		"rgba": "rgba(0, 0, 0, 0.24)",
+		"hex": "#3d000000",
+		"figma": "static_monochrome-black/24",
+		"web": "--color-static-monochrome-black-24",
+		"alias": "staticMonochromeBlackColor24"
+	},
+	"static_monochrome_black_32": {
+		"rgba": "rgba(0, 0, 0, 0.32)",
+		"hex": "#52000000",
+		"figma": "static_monochrome-black/32",
+		"web": "--color-static-monochrome-black-32",
+		"alias": "staticMonochromeBlackColor32"
+	},
+	"static_monochrome_black_4": {
+		"rgba": "rgba(0, 0, 0, 0.04)",
+		"hex": "#0a000000",
+		"figma": "static_monochrome-black/4",
+		"web": "--color-static-monochrome-black-4",
+		"alias": "staticMonochromeBlackColor4"
+	},
+	"static_monochrome_black_40": {
+		"rgba": "rgba(0, 0, 0, 0.4)",
+		"hex": "#66000000",
+		"figma": "static_monochrome-black/40",
+		"web": "--color-static-monochrome-black-40",
+		"alias": "staticMonochromeBlackColor40"
+	},
+	"static_monochrome_black_44": {
+		"rgba": "rgba(0, 0, 0, 0.44)",
+		"hex": "#70000000",
+		"figma": "static_monochrome-black/44",
+		"web": "--color-static-monochrome-black-44",
+		"alias": "staticMonochromeBlackColor44"
+	},
+	"static_monochrome_black_48": {
+		"rgba": "rgba(0, 0, 0, 0.48)",
+		"hex": "#7a000000",
+		"figma": "static_monochrome-black/48",
+		"web": "--color-static-monochrome-black-48",
+		"alias": "staticMonochromeBlackColor48"
+	},
+	"static_monochrome_black_56": {
+		"rgba": "rgba(0, 0, 0, 0.56)",
+		"hex": "#8f000000",
+		"figma": "static_monochrome-black/56",
+		"web": "--color-static-monochrome-black-56",
+		"alias": "staticMonochromeBlackColor56"
+	},
+	"static_monochrome_black_6": {
+		"rgba": "rgba(0, 0, 0, 0.06)",
+		"hex": "#0f000000",
+		"figma": "static_monochrome-black/6",
+		"web": "--color-static-monochrome-black-6",
+		"alias": "staticMonochromeBlackColor6"
+	},
+	"static_monochrome_black_64": {
+		"rgba": "rgba(0, 0, 0, 0.64)",
+		"hex": "#a3000000",
+		"figma": "static_monochrome-black/64",
+		"web": "--color-static-monochrome-black-64",
+		"alias": "staticMonochromeBlackColor64"
+	},
+	"static_monochrome_black_72": {
+		"rgba": "rgba(0, 0, 0, 0.72)",
+		"hex": "#b8000000",
+		"figma": "static_monochrome-black/72",
+		"web": "--color-static-monochrome-black-72",
+		"alias": "staticMonochromeBlackColor72"
+	},
+	"static_monochrome_black_8": {
+		"rgba": "rgba(0, 0, 0, 0.08)",
+		"hex": "#14000000",
+		"figma": "static_monochrome-black/8",
+		"web": "--color-static-monochrome-black-8",
+		"alias": "staticMonochromeBlackColor8"
+	},
+	"static_monochrome_black_80": {
+		"rgba": "rgba(0, 0, 0, 0.8)",
+		"hex": "#cc000000",
+		"figma": "static_monochrome-black/80",
+		"web": "--color-static-monochrome-black-80",
+		"alias": "staticMonochromeBlackColor80"
+	},
+	"static_monochrome_black_88": {
+		"rgba": "rgba(0, 0, 0, 0.88)",
+		"hex": "#e0000000",
+		"figma": "static_monochrome-black/88",
+		"web": "--color-static-monochrome-black-88",
+		"alias": "staticMonochromeBlackColor88"
+	},
+	"static_monochrome_white_10": {
+		"rgba": "rgba(255, 255, 255, 0.1)",
+		"hex": "#1affffff",
+		"figma": "static_monochrome-white/10",
+		"web": "--color-static-monochrome-white-10",
+		"alias": "staticMonochromeWhiteColor10"
+	},
+	"static_monochrome_white_100": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "static_monochrome-white/100",
+		"web": "--color-static-monochrome-white-100",
+		"alias": "staticMonochromeWhiteColor100"
+	},
+	"static_monochrome_white_12": {
+		"rgba": "rgba(255, 255, 255, 0.12)",
+		"hex": "#1fffffff",
+		"figma": "static_monochrome-white/12",
+		"web": "--color-static-monochrome-white-12",
+		"alias": "staticMonochromeWhiteColor12"
+	},
+	"static_monochrome_white_16": {
+		"rgba": "rgba(255, 255, 255, 0.16)",
+		"hex": "#29ffffff",
+		"figma": "static_monochrome-white/16",
+		"web": "--color-static-monochrome-white-16",
+		"alias": "staticMonochromeWhiteColor16"
+	},
+	"static_monochrome_white_2": {
+		"rgba": "rgba(255, 255, 255, 0.02)",
+		"hex": "#05ffffff",
+		"figma": "static_monochrome-white/2",
+		"web": "--color-static-monochrome-white-2",
+		"alias": "staticMonochromeWhiteColor2"
+	},
+	"static_monochrome_white_20": {
+		"rgba": "rgba(255, 255, 255, 0.2)",
+		"hex": "#33ffffff",
+		"figma": "static_monochrome-white/20",
+		"web": "--color-static-monochrome-white-20",
+		"alias": "staticMonochromeWhiteColor20"
+	},
+	"static_monochrome_white_24": {
+		"rgba": "rgba(255, 255, 255, 0.24)",
+		"hex": "#3dffffff",
+		"figma": "static_monochrome-white/24",
+		"web": "--color-static-monochrome-white-24",
+		"alias": "staticMonochromeWhiteColor24"
+	},
+	"static_monochrome_white_32": {
+		"rgba": "rgba(255, 255, 255, 0.32)",
+		"hex": "#52ffffff",
+		"figma": "static_monochrome-white/32",
+		"web": "--color-static-monochrome-white-32",
+		"alias": "staticMonochromeWhiteColor32"
+	},
+	"static_monochrome_white_4": {
+		"rgba": "rgba(255, 255, 255, 0.04)",
+		"hex": "#0affffff",
+		"figma": "static_monochrome-white/4",
+		"web": "--color-static-monochrome-white-4",
+		"alias": "staticMonochromeWhiteColor4"
+	},
+	"static_monochrome_white_40": {
+		"rgba": "rgba(255, 255, 255, 0.4)",
+		"hex": "#66ffffff",
+		"figma": "static_monochrome-white/40",
+		"web": "--color-static-monochrome-white-40",
+		"alias": "staticMonochromeWhiteColor40"
+	},
+	"static_monochrome_white_44": {
+		"rgba": "rgba(255, 255, 255, 0.44)",
+		"hex": "#70ffffff",
+		"figma": "static_monochrome-white/44",
+		"web": "--color-static-monochrome-white-44",
+		"alias": "staticMonochromeWhiteColor44"
+	},
+	"static_monochrome_white_48": {
+		"rgba": "rgba(255, 255, 255, 0.48)",
+		"hex": "#7affffff",
+		"figma": "static_monochrome-white/48",
+		"web": "--color-static-monochrome-white-48",
+		"alias": "staticMonochromeWhiteColor48"
+	},
+	"static_monochrome_white_56": {
+		"rgba": "rgba(255, 255, 255, 0.56)",
+		"hex": "#8fffffff",
+		"figma": "static_monochrome-white/56",
+		"web": "--color-static-monochrome-white-56",
+		"alias": "staticMonochromeWhiteColor56"
+	},
+	"static_monochrome_white_6": {
+		"rgba": "rgba(255, 255, 255, 0.06)",
+		"hex": "#0fffffff",
+		"figma": "static_monochrome-white/6",
+		"web": "--color-static-monochrome-white-6",
+		"alias": "staticMonochromeWhiteColor6"
+	},
+	"static_monochrome_white_64": {
+		"rgba": "rgba(255, 255, 255, 0.64)",
+		"hex": "#a3ffffff",
+		"figma": "static_monochrome-white/64",
+		"web": "--color-static-monochrome-white-64",
+		"alias": "staticMonochromeWhiteColor64"
+	},
+	"static_monochrome_white_72": {
+		"rgba": "rgba(255, 255, 255, 0.72)",
+		"hex": "#b8ffffff",
+		"figma": "static_monochrome-white/72",
+		"web": "--color-static-monochrome-white-72",
+		"alias": "staticMonochromeWhiteColor72"
+	},
+	"static_monochrome_white_8": {
+		"rgba": "rgba(255, 255, 255, 0.08)",
+		"hex": "#14ffffff",
+		"figma": "static_monochrome-white/8",
+		"web": "--color-static-monochrome-white-8",
+		"alias": "staticMonochromeWhiteColor8"
+	},
+	"static_monochrome_white_80": {
+		"rgba": "rgba(255, 255, 255, 0.8)",
+		"hex": "#ccffffff",
+		"figma": "static_monochrome-white/80",
+		"web": "--color-static-monochrome-white-80",
+		"alias": "staticMonochromeWhiteColor80"
+	},
+	"static_monochrome_white_88": {
+		"rgba": "rgba(255, 255, 255, 0.88)",
+		"hex": "#e0ffffff",
+		"figma": "static_monochrome-white/88",
+		"web": "--color-static-monochrome-white-88",
+		"alias": "staticMonochromeWhiteColor88"
 	}
 }

--- a/styles/colors_students.json
+++ b/styles/colors_students.json
@@ -1,16 +1,16 @@
 {
 	"static_students_electric_lime": {
 		"rgba": "rgba(143, 255, 0, 1)",
-		"hex": "#8FFF00",
+		"hex": "#8fff00",
 		"figma": "static_students/electric-lime",
-		"alias": "staticStudentsColorElectricLime",
-		"web": "--color-static-students-electric-lime"
+		"web": "--color-static-students-electric-lime",
+		"alias": "staticStudentsColorElectricLime"
 	},
 	"static_students_razzle_rose": {
 		"rgba": "rgba(254, 52, 198, 1)",
-		"hex": "#FE34C6",
+		"hex": "#fe34c6",
 		"figma": "static_students/razzle-rose",
-		"alias": "staticStudentsColorRazzleRose",
-		"web": "--color-static-students-razzle-rose"
+		"web": "--color-static-students-razzle-rose",
+		"alias": "staticStudentsColorRazzleRose"
 	}
 }

--- a/styles/colors_x5.json
+++ b/styles/colors_x5.json
@@ -1,4 +1,11 @@
 {
+	"static_brand_orange": {
+		"rgba": "rgba(247, 97, 0, 1)",
+		"hex": "#f76100",
+		"figma": "static/brand/orange",
+		"web": "--color-static-brand-orange",
+		"alias": "staticBrandColorOrange"
+	},
 	"static_brand_primary": {
 		"rgba": "rgba(95, 175, 45, 1)",
 		"hex": "#5faf2d",
@@ -12,12 +19,5 @@
 		"figma": "static/brand/secondary",
 		"web": "--color-static-brand-secondary",
 		"alias": "staticBrandColorSecondary"
-	},
-	"static_brand_orange": {
-		"rgba": "rgba(247, 97, 0, 1)",
-		"hex": "#f76100",
-		"figma": "static/brand/orange",
-		"web": "--color-static-brand-orange",
-		"alias": "staticBrandColorOrange"
 	}
 }

--- a/styles/colors_x5.json
+++ b/styles/colors_x5.json
@@ -2,20 +2,22 @@
 	"static_brand_primary": {
 		"rgba": "rgba(95, 175, 45, 1)",
 		"hex": "#5faf2d",
-		"alias": "staticBrandColorPrimary",
-		"web": "--color-static-brand-primary"
+		"figma": "static/brand/primary",
+		"web": "--color-static-brand-primary",
+		"alias": "staticBrandColorPrimary"
 	},
 	"static_brand_secondary": {
 		"rgba": "rgba(0, 175, 255, 1)",
 		"hex": "#00afff",
-		"alias": "staticBrandColorSecondary",
-		"web": "--color-static-brand-secondary"
+		"figma": "static/brand/secondary",
+		"web": "--color-static-brand-secondary",
+		"alias": "staticBrandColorSecondary"
 	},
 	"static_brand_orange": {
 		"rgba": "rgba(247, 97, 0, 1)",
 		"hex": "#f76100",
 		"figma": "static/brand/orange",
-		"alias": "staticBrandColorOrange",
-		"web": "--color-static-brand-orange"
+		"web": "--color-static-brand-orange",
+		"alias": "staticBrandColorOrange"
 	}
 }


### PR DESCRIPTION
## Что изменилось

Цветовые токены синхронизированы со всеми десятью экспортными страницами файла Color Exporter через Figma REST.

- BlueTint: 37 токенов, которых больше нет на странице Figma, получили `deprecated: true` и перенесены в отдельный отсортированный хвост;
- Brand: `static_brand_blue` обновлён с `#0056ff` до `#0057ff` (`rgba(0, 87, 255, 1)`);
- Students и Go: цветовые значения не изменились, файлы приведены к единому формату JSON;
- Monochrome и X5 приведены к общему алфавитному порядку по полному JSON-ключу, без специальных правил отдельных наборов;
- X5: для `primary` и `secondary` также добавлены отсутствовавшие пути `figma`, у всех трёх токенов нормализован порядок полей;
- Decorative, Qualitative, Sequential и Promo полностью проверены и уже совпадали с Figma.

Для Monochrome общий порядок начинается с `dark`, затем идёт `light`, затем `static`; числовые части сравниваются как часть строки. Порядок X5 теперь равен `orange`, `primary`, `secondary`. Цветовые значения обоих наборов при пересортировке не изменились.

## Новые deprecated-токены

Ниже перечислены только 37 ключей, которые впервые получили `deprecated: true` в этом PR. Токены, устаревшие до этого PR, повторно не перечисляются.

```text
dark_neutral_1500
dark_neutral_1500_hover
dark_neutral_1500_inverted
dark_neutral_1500_inverted_hover
dark_neutral_1500_inverted_press
dark_neutral_1500_press
dark_neutral_translucent_1500_hover
dark_neutral_translucent_1500_inverted_hover
dark_neutral_translucent_1500_inverted_press
dark_neutral_translucent_1500_press
light_neutral_1500
light_neutral_1500_hover
light_neutral_1500_inverted
light_neutral_1500_inverted_hover
light_neutral_1500_inverted_press
light_neutral_1500_press
light_neutral_translucent_1500_hover
light_neutral_translucent_1500_inverted_hover
light_neutral_translucent_1500_inverted_press
light_neutral_translucent_1500_press
static_bg_primary_dark
static_neutral_1500
static_neutral_1500_hover
static_neutral_1500_inverted
static_neutral_1500_inverted_hover
static_neutral_1500_inverted_press
static_neutral_1500_press
static_neutral_translucent_1500_hover
static_neutral_translucent_1500_inverted_hover
static_neutral_translucent_1500_inverted_press
static_neutral_translucent_1500_press
static_text_primary_dark
static_text_primary_light
static_text_secondary_dark
static_text_secondary_light
static_text_tertiary_dark
static_text_tertiary_light
```

## Результат по страницам

| Страница | Активные | Устаревшие | Результат |
|---|---:|---:|---|
| `colors_bluetint.json` | 692 | 200 | 37 отсутствующих в Figma токенов помечены устаревшими |
| `colors_brand.json` | 8 | 0 | обновлено значение одного активного токена |
| `colors_decorative.json` | 612 | 0 | изменений не требуется |
| `colors_go.json` | 7 | 0 | значения не изменились; нормализован формат JSON |
| `colors_monochrome.json` | 190 | 0 | значения не изменились; применён общий алфавитный порядок |
| `colors_promo.json` | 223 | 32 | изменений не требуется; 32 токена, существующих только в коде, остаются устаревшими |
| `colors_qualitative.json` | 128 | 0 | изменений не требуется |
| `colors_sequential.json` | 192 | 0 | изменений не требуется |
| `colors_students.json` | 2 | 0 | значения не изменились; нормализован формат JSON |
| `colors_x5.json` | 3 | 0 | добавлены два пути `figma`; применён общий алфавитный порядок |

Итого проверено 169 секций, 1 151 фрейм и 2 059 прямоугольников. Экспортировано 2 057 активных токенов; ещё 232 исторических токена находятся в отдельных устаревших блоках.

## Правила синхронизации

- преобразование выполнено детерминированным кодом без ИИ и без Figma MCP;
- активные токены всех наборов сортируются по полному JSON-ключу;
- активный токен каждый раз полностью создаётся в порядке `rgba`, `hex`, `figma`, `web`, `alias`;
- отсутствующий в Figma токен не удаляется: он получает `deprecated: true` и переносится в отдельный отсортированный хвост;
- новые допустимые токены проходят те же формулы, что существующие;
- локальный драфт экспортёра остаётся вне этого PR;
- автоматическое слияние PR не выполняется.

## Проверки

- 30 локальных тестов экспортёра прошли на Node.js 24;
- все десять страниц прочитаны одним запуском через Figma REST;
- повторный запуск в режиме `--check` показал отсутствие изменений для всех десяти JSON;
- в изменениях PR находятся только `styles/colors_bluetint.json`, `styles/colors_brand.json`, `styles/colors_go.json`, `styles/colors_monochrome.json`, `styles/colors_students.json` и `styles/colors_x5.json`.
