### PR TITLE
feat(styles): add superapp shadows

### DIFF
--- a/styles/shadows_superapp.json
+++ b/styles/shadows_superapp.json
@@ -1,0 +1,30 @@
+{
+	"shadow_1": [
+		{
+			"offset_x": 0,
+			"offset_y": 2,
+			"blur_radius": 8,
+			"spread_radius": 0,
+			"rgba": "rgba(0, 0, 0, 0.04)",
+			"hex": "#0a000000"
+		},
+		{
+			"offset_x": 0,
+			"offset_y": 4,
+			"blur_radius": 40,
+			"spread_radius": 8,
+			"rgba": "rgba(0, 0, 0, 0.024)",
+			"hex": "#06000000"
+		}
+	],
+	"shadow_2": [
+		{
+			"offset_x": 0,
+			"offset_y": 4,
+			"blur_radius": 16,
+			"spread_radius": 0,
+			"rgba": "rgba(3, 3, 6, 0.08)",
+			"hex": "#14030306"
+		}
+	]
+}


### PR DESCRIPTION
Добавляет `styles/shadows_superapp.json` с двумя актуальными тенями из [SuperApp Tokens — UI Kit](https://www.figma.com/design/2iMH5AhGzRwsFsTEmUzpxb/SuperApp-Tokens---UI-Kit?node-id=192-42528): `superapp/shadow-1` → `shadow_1`, `superapp/shadow-2` → `shadow_2`.

Сохраняет структуру существующего `shadows_bluetint.json`: массив слоёв, смещения, размытие, `rgba` и `hex` в формате `#AARRGGBB`. Добавляет `spread_radius`, чтобы передать расширение первого стиля на 8 px; нулевое расширение также указано явно. Непрозрачность 2,4% сохранена в `rgba` как `0.024`; в восьмибитном альфа-канале `hex` это `06`. Порядок слоёв соответствует действующему экспорту BlueTint для обычных и усиленных теней: обратный порядку массива эффектов Figma. Стили из раздела «Старые тени» не включены.

Проверено: оба актуальных стиля и все три слоя сверены с Figma по геометрии, расширению, цвету, значению альфа-канала и порядку; JSON и пробелы проверены; `npm pack --dry-run --ignore-scripts` включает новый файл в пакет.

Подключение теней в потребителях не входит в это изменение. Для точного воспроизведения расширения потребитель должен учитывать новое поле `spread_radius`. Остальные настройки эффекта Figma, в том числе `showShadowBehindNode` (отображение тени под самим слоем), не представлены в существующем формате экспорта и в этот файл не добавляются. Визуальная проверка в приложениях-потребителях не выполнялась.
