### PR TITLE
feat(styles): добавить цвета SuperApp

### DIFF
--- a/styles/colors_superapp.json
+++ b/styles/colors_superapp.json
@@ -1,0 +1,44 @@
+{
+	"dark_superapp_base_bg_primary": {
+		"rgba": "rgba(28, 28, 30, 1)",
+		"hex": "#1c1c1e",
+		"figma": "superapp-base-bg/primary",
+		"web": "--color-dark-superapp-base-bg-primary",
+		"alias": "superappBaseBgColorPrimary"
+	},
+	"dark_superapp_base_bg_secondary": {
+		"rgba": "rgba(40, 40, 43, 1)",
+		"hex": "#28282b",
+		"figma": "superapp-base-bg/secondary",
+		"web": "--color-dark-superapp-base-bg-secondary",
+		"alias": "superappBaseBgColorSecondary"
+	},
+	"dark_superapp_tab_bg_selected": {
+		"rgba": "rgba(33, 33, 36, 1)",
+		"hex": "#212124",
+		"figma": "superapp-tab/bg-selected",
+		"web": "--color-dark-superapp-tab-bg-selected",
+		"alias": "superappTabColorBgSelected"
+	},
+	"light_superapp_base_bg_primary": {
+		"rgba": "rgba(252, 252, 252, 1)",
+		"hex": "#fcfcfc",
+		"figma": "superapp-base-bg/primary",
+		"web": "--color-light-superapp-base-bg-primary",
+		"alias": "superappBaseBgColorPrimary"
+	},
+	"light_superapp_base_bg_secondary": {
+		"rgba": "rgba(255, 255, 255, 1)",
+		"hex": "#ffffff",
+		"figma": "superapp-base-bg/secondary",
+		"web": "--color-light-superapp-base-bg-secondary",
+		"alias": "superappBaseBgColorSecondary"
+	},
+	"light_superapp_tab_bg_selected": {
+		"rgba": "rgba(252, 252, 252, 1)",
+		"hex": "#fcfcfc",
+		"figma": "superapp-tab/bg-selected",
+		"web": "--color-light-superapp-tab-bg-selected",
+		"alias": "superappTabColorBgSelected"
+	}
+}

--- a/styles/colors_superapp.json
+++ b/styles/colors_superapp.json
@@ -21,8 +21,8 @@
 		"alias": "superappTabColorBgSelected"
 	},
 	"dark_superapp_tab_bg_selected_press": {
-		"rgba": "rgba(59, 59, 64, 1)",
-		"hex": "#3b3b40",
+		"rgba": "rgba(63, 63, 69, 1)",
+		"hex": "#3f3f45",
 		"figma": "superapp-tab/bg-selected/press",
 		"web": "--color-dark-superapp-tab-bg-selected-press",
 		"alias": "superappTabColorBgSelectedPress"

--- a/styles/colors_superapp.json
+++ b/styles/colors_superapp.json
@@ -14,11 +14,18 @@
 		"alias": "superappBaseBgColorSecondary"
 	},
 	"dark_superapp_tab_bg_selected": {
-		"rgba": "rgba(33, 33, 36, 1)",
-		"hex": "#212124",
+		"rgba": "rgba(59, 59, 64, 1)",
+		"hex": "#3b3b40",
 		"figma": "superapp-tab/bg-selected",
 		"web": "--color-dark-superapp-tab-bg-selected",
 		"alias": "superappTabColorBgSelected"
+	},
+	"dark_superapp_tab_bg_selected_press": {
+		"rgba": "rgba(59, 59, 64, 1)",
+		"hex": "#3b3b40",
+		"figma": "superapp-tab/bg-selected/press",
+		"web": "--color-dark-superapp-tab-bg-selected-press",
+		"alias": "superappTabColorBgSelectedPress"
 	},
 	"light_superapp_base_bg_primary": {
 		"rgba": "rgba(252, 252, 252, 1)",
@@ -35,10 +42,17 @@
 		"alias": "superappBaseBgColorSecondary"
 	},
 	"light_superapp_tab_bg_selected": {
-		"rgba": "rgba(252, 252, 252, 1)",
-		"hex": "#fcfcfc",
+		"rgba": "rgba(248, 248, 248, 1)",
+		"hex": "#f8f8f8",
 		"figma": "superapp-tab/bg-selected",
 		"web": "--color-light-superapp-tab-bg-selected",
 		"alias": "superappTabColorBgSelected"
+	},
+	"light_superapp_tab_bg_selected_press": {
+		"rgba": "rgba(242, 242, 242, 1)",
+		"hex": "#f2f2f2",
+		"figma": "superapp-tab/bg-selected/press",
+		"web": "--color-light-superapp-tab-bg-selected-press",
+		"alias": "superappTabColorBgSelectedPress"
 	}
 }


### PR DESCRIPTION
Добавлен `styles/colors_superapp.json` — цвета SuperApp для режимов `light` и `dark`.

- `superapp-surface-bg/primary` — `default`.
- `superapp-surface-bg/secondary` — `default`.
- `superapp-component-bg/secondary` — `default` и `press`.

Всего восемь записей.